### PR TITLE
Fix - ISA docs `mov dst, imm`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         cargo fmt --all -- --check
         cargo clippy --all --tests -- --deny=warnings
-      if: matrix.rust == 'nightly'
+      if: matrix.rust == 'beta'
       shell: bash
     - name: Build and test
       run: |
@@ -45,7 +45,7 @@ jobs:
       run: |
         cargo fmt --all --manifest-path cli/Cargo.toml -- --check
         cargo clippy --all --tests --manifest-path cli/Cargo.toml -- --deny=warnings
-      if: matrix.rust == 'nightly'
+      if: matrix.rust == 'beta'
       shell: bash
     - name: CLI - Build and test
       run: |

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-doc-valid-idents = ["eBPF", "uBPF"] 

--- a/doc/bytecode.md
+++ b/doc/bytecode.md
@@ -114,7 +114,7 @@ The following Rust equivalents assume that:
 | `9C` / `01111001`  | from v2     | `ldxdw dst, [src + off]`
 | `A4` / `10100100`  | all         | `xor32 dst, imm`       | `dst = (dst as u32).xor(imm) as u64`
 | `AC` / `10101100`  | all         | `xor32 dst, src`       | `dst = (dst as u32).xor(src as u32) as u64`
-| `B4` / `10110100`  | all         | `mov32 dst, imm`       | `dst = imm as i32 as i64 as u64`
+| `B4` / `10110100`  | all         | `mov32 dst, imm`       | `dst = imm as u64`
 | `BC` / `10111100`  | until v2    | `mov32 dst, src`       | `dst = src as u32 as u64`
 | `BC` / `10111100`  | from v2     | `mov32 dst, src`       | `dst = src as i32 as i64 as u64`
 | `C4` / `11000100`  | all         | `ash32 dst, imm`       | `dst = (dst as i32).wrapping_shr(imm) as u32 as u64`
@@ -158,7 +158,7 @@ The following Rust equivalents assume that:
 | `9F` / `01111011`  | from v2     | `stxdw [dst + off], src`
 | `A7` / `10100111`  | all         | `xor64 dst, imm`   | `dst = dst.xor(imm)`
 | `AF` / `10101111`  | all         | `xor64 dst, src`   | `dst = dst.xor(src)`
-| `B7` / `10110111`  | all         | `mov64 dst, imm`   | `dst = imm as u64`
+| `B7` / `10110111`  | all         | `mov64 dst, imm`   | `dst = imm as i32 as i64 as u64`
 | `BF` / `10111111`  | all         | `mov64 dst, src`   | `dst = src`
 | `C7` / `11000111`  | all         | `ash64 dst, imm`   | `dst = (dst as i64).wrapping_shr(imm)`
 | `CF` / `11001111`  | all         | `ash64 dst, src`   | `dst = (dst as i64).wrapping_shr(src as u32)`

--- a/src/insn_builder.rs
+++ b/src/insn_builder.rs
@@ -89,7 +89,7 @@ impl<I: Instruction> IntoBytes for &I {
     fn into_bytes(self) -> Self::Bytes {
         vec![
             self.opt_code_byte(),
-            self.get_src() << 4 | self.get_dst(),
+            (self.get_src() << 4) | self.get_dst(),
             self.get_off() as u8,
             (self.get_off() >> 8) as u8,
             self.get_imm() as u8,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1365,7 +1365,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             }
         }
 
-        self.emit_ins(X86Instruction::alu_immediate(size, 0xf7, 0x4 | (division as u8) << 1 | signed as u8, REGISTER_SCRATCH, 0, None));
+        self.emit_ins(X86Instruction::alu_immediate(size, 0xf7, 0x4 | ((division as u8) << 1) | signed as u8, REGISTER_SCRATCH, 0, None));
 
         if dst != RDX {
             if alt_dst {


### PR DESCRIPTION
Also demotes the clippy and fmt in CI from Rust nightly to Rust beta as [clippy::literal_string_with_formatting_args](https://rust-lang.github.io/rust-clippy/master/index.html#literal_string_with_formatting_args) is currently broken and incorrectly marks code comments as problematic.