### PR TITLE
Fix - Assembler source R0 for CALL_IMM

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -431,7 +431,7 @@ pub fn assemble<C: ContextObject>(
                                         target_pc as usize,
                                     )
                                     .map_err(|_| format!("Label hash collision {name}"))?;
-                                insn(opc, 0, 1, 0, instr_imm)
+                                insn(opc, 0, 0, 0, instr_imm)
                             }
                             (CallReg, [Register(dst)]) => {
                                 if sbpf_version.callx_uses_src_reg() {

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -152,7 +152,7 @@ fn test_call_reg() {
 fn test_call_imm() {
     assert_eq!(
         asm("call 299"),
-        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 1, 0, 299)])
+        Ok(vec![insn(0, ebpf::CALL_IMM, 0, 0, 0, 299)])
     );
 }
 


### PR DESCRIPTION
SBPFv3 differentiates syscalls in a separate opcode. Thus there is no more need for abusing the src reg field.