### PR TITLE
fix vm.due_insn_count subtract overflow when enable_instruction_meter=false

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -344,11 +344,7 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
         self.registers[1] = ebpf::MM_INPUT_START;
         self.registers[11] = executable.get_entrypoint_instruction_offset() as u64;
         let config = executable.get_config();
-        let initial_insn_count = if config.enable_instruction_meter {
-            self.context_object_pointer.get_remaining()
-        } else {
-            0
-        };
+        let initial_insn_count = self.context_object_pointer.get_remaining();
         self.previous_instruction_meter = initial_insn_count;
         self.due_insn_count = 0;
         self.program_result = ProgramResult::Ok(0);


### PR DESCRIPTION
I found a corner case.

if config.enable_instruction_meter=false & jit is off,
vm.due_insn_count subtract overflow encoutered at

https://github.com/anza-xyz/sbpf/blob/946f7d98b1df466af547878ba8f276e7f2642229/src/interpreter.rs#L590-L590

that's because we set previous_instruction_meter to 0 when config.enable_instruction_meter is set to false
https://github.com/anza-xyz/sbpf/blob/946f7d98b1df466af547878ba8f276e7f2642229/src/vm.rs#L347-L352


I confirmed that it exists in interpreter mode, 
but I'm not sure about the behavior in JIT mode (request for review)