### PR TITLE
Refactor - AccessViolationHandler

### DIFF
--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -72,7 +72,7 @@ macro_rules! bench_gapped_randomized_access_with_1024_entries {
                         false,
                     )];
                     let config = Config::default();
-                    let memory_mapping =
+                    let mut memory_mapping =
                         $mem::new(memory_regions, &config, SBPFVersion::V4).unwrap();
                     let mut prng = new_prng!();
                     bencher.iter(|| {
@@ -111,7 +111,7 @@ macro_rules! bench_randomized_access_with_0001_entry {
             let content = vec![0; 1024 * 2];
             let memory_regions = vec![MemoryRegion::new_readonly(&content[..], 0x100000000)];
             let config = Config::default();
-            let memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V4).unwrap();
+            let mut memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V4).unwrap();
             let mut prng = new_prng!();
             bencher.iter(|| {
                 let _ = memory_mapping.map(
@@ -144,7 +144,7 @@ macro_rules! bench_randomized_access_with_n_entries {
             let mut prng = new_prng!();
             let (memory_regions, end_address) = generate_memory_regions($n, false, Some(&mut prng));
             let config = Config::default();
-            let memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V4).unwrap();
+            let mut memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V4).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(
                     AccessType::Load,
@@ -193,7 +193,7 @@ macro_rules! bench_randomized_mapping_with_n_entries {
             let (memory_regions, _end_address) =
                 generate_memory_regions($n, false, Some(&mut prng));
             let config = Config::default();
-            let memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V4).unwrap();
+            let mut memory_mapping = $mem::new(memory_regions, &config, SBPFVersion::V4).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(AccessType::Load, 0x100000000, 1);
             });
@@ -297,7 +297,7 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation) {
         aligned_memory_mapping: false,
         ..Config::default()
     };
-    let memory_mapping = MemoryMapping::new(
+    let mut memory_mapping = MemoryMapping::new(
         vec![
             MemoryRegion::new_writable(&mut mem1, vm_addr),
             MemoryRegion::new_writable(&mut mem2, vm_addr + 8),

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -73,7 +73,7 @@ macro_rules! bench_gapped_randomized_access_with_1024_entries {
                         frame_size,
                         false,
                     )];
-                    let mut memory_mapping =
+                    let memory_mapping =
                         MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
                     let mut prng = new_prng!();
                     bencher.iter(|| {
@@ -115,7 +115,7 @@ macro_rules! bench_randomized_access_with_0001_entry {
                 aligned_memory_mapping: $aligned_memory_mapping,
                 ..Config::default()
             };
-            let mut memory_mapping =
+            let memory_mapping =
                 MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
             let mut prng = new_prng!();
             bencher.iter(|| {
@@ -152,7 +152,7 @@ macro_rules! bench_randomized_access_with_n_entries {
                 aligned_memory_mapping: $aligned_memory_mapping,
                 ..Config::default()
             };
-            let mut memory_mapping =
+            let memory_mapping =
                 MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(
@@ -202,7 +202,7 @@ macro_rules! bench_randomized_mapping_with_n_entries {
             let (memory_regions, _end_address) =
                 generate_memory_regions($n, false, Some(&mut prng));
             let config = Config::default();
-            let mut memory_mapping =
+            let memory_mapping =
                 MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(AccessType::Load, 0x100000000, 1);
@@ -254,7 +254,7 @@ macro_rules! bench_mapping_with_n_entries {
                 aligned_memory_mapping: $aligned_memory_mapping,
                 ..Config::default()
             };
-            let mut memory_mapping =
+            let memory_mapping =
                 MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(AccessType::Load, 0x100000000, 1);

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -12,7 +12,9 @@ extern crate test;
 
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use solana_sbpf::{
-    memory_region::{AccessType, AlignedMemoryMapping, MemoryRegion, UnalignedMemoryMapping},
+    memory_region::{
+        AccessType, AlignedMemoryMapping, MemoryMapping, MemoryRegion, UnalignedMemoryMapping,
+    },
     program::SBPFVersion,
     vm::Config,
 };
@@ -287,14 +289,18 @@ enum MemoryOperation {
     Store(u64),
 }
 
-fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation, vm_addr: u64) {
+fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation) {
+    let vm_addr = 0x100000000;
     let mut mem1 = vec![0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18];
     let mut mem2 = vec![0x22; 1];
-    let config = Config::default();
-    let memory_mapping = UnalignedMemoryMapping::new(
+    let config = Config {
+        aligned_memory_mapping: false,
+        ..Config::default()
+    };
+    let memory_mapping = MemoryMapping::new(
         vec![
-            MemoryRegion::new_writable(&mut mem1, 0x100000000),
-            MemoryRegion::new_writable(&mut mem2, 0x100000000 + 8),
+            MemoryRegion::new_writable(&mut mem1, vm_addr),
+            MemoryRegion::new_writable(&mut mem2, vm_addr + 8),
         ],
         &config,
         SBPFVersion::V4,
@@ -316,25 +322,15 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation, vm_add
 
 #[bench]
 fn bench_mapping_8_byte_map(bencher: &mut Bencher) {
-    do_bench_mapping_operation(bencher, MemoryOperation::Map, 0x100000000)
+    do_bench_mapping_operation(bencher, MemoryOperation::Map)
 }
 
 #[bench]
 fn bench_mapping_8_byte_load(bencher: &mut Bencher) {
-    do_bench_mapping_operation(bencher, MemoryOperation::Load, 0x100000000)
-}
-
-#[bench]
-fn bench_mapping_8_byte_load_non_contiguous(bencher: &mut Bencher) {
-    do_bench_mapping_operation(bencher, MemoryOperation::Load, 0x100000001)
+    do_bench_mapping_operation(bencher, MemoryOperation::Load)
 }
 
 #[bench]
 fn bench_mapping_8_byte_store(bencher: &mut Bencher) {
-    do_bench_mapping_operation(bencher, MemoryOperation::Store(42), 0x100000000)
-}
-
-#[bench]
-fn bench_mapping_8_byte_store_non_contiguous(bencher: &mut Bencher) {
-    do_bench_mapping_operation(bencher, MemoryOperation::Store(42), 0x100000001)
+    do_bench_mapping_operation(bencher, MemoryOperation::Store(42))
 }

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -251,22 +251,6 @@ impl<'a> UnalignedMemoryMapping<'a> {
         Ok(result)
     }
 
-    /// Creates a new memory mapping for tests and benches.
-    ///
-    /// `access_violation_handler` defaults to a function which always returns an error.
-    pub fn new(
-        regions: Vec<MemoryRegion>,
-        config: &'a Config,
-        sbpf_version: SBPFVersion,
-    ) -> Result<Self, EbpfError> {
-        Self::new_with_access_violation_handler(
-            regions,
-            config,
-            sbpf_version,
-            Box::new(default_access_violation_handler),
-        )
-    }
-
     /// Returns the `MemoryRegion` which may contain the given address.
     #[allow(clippy::arithmetic_side_effects)]
     pub fn find_region(&self, vm_addr: u64) -> Option<(usize, &MemoryRegion)> {
@@ -360,22 +344,6 @@ impl<'a> AlignedMemoryMapping<'a> {
                 sbpf_version,
             },
         })
-    }
-
-    /// Creates a new memory mapping for tests and benches.
-    ///
-    /// `access_violation_handler` defaults to a function which always returns an error.
-    pub fn new(
-        regions: Vec<MemoryRegion>,
-        config: &'a Config,
-        sbpf_version: SBPFVersion,
-    ) -> Result<Self, EbpfError> {
-        Self::new_with_access_violation_handler(
-            regions,
-            config,
-            sbpf_version,
-            Box::new(default_access_violation_handler),
-        )
     }
 
     /// Returns the `MemoryRegion` which may contain the given address.

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -302,27 +302,15 @@ impl<'a> UnalignedMemoryMapping<'a> {
 
     /// Given a list of regions translate from virtual machine to host address
     pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64) -> ProgramResult {
-        let region = match self.find_region(vm_addr) {
-            Some((_region_index, region)) => region,
-            None => {
-                return generate_access_violation(
-                    self.config,
-                    self.sbpf_version,
-                    access_type,
-                    vm_addr,
-                    len,
-                )
-            }
-        };
-
-        if access_type == AccessType::Load
-            || ensure_writable_region(region, &self.access_violation_handler)
-        {
-            if let Some(host_addr) = region.vm_to_host(vm_addr, len) {
-                return ProgramResult::Ok(host_addr);
+        if let Some((_index, region)) = self.find_region(vm_addr) {
+            if access_type == AccessType::Load
+                || ensure_writable_region(region, &self.access_violation_handler)
+            {
+                if let Some(host_addr) = region.vm_to_host(vm_addr, len) {
+                    return ProgramResult::Ok(host_addr);
+                }
             }
         }
-
         generate_access_violation(self.config, self.sbpf_version, access_type, vm_addr, len)
     }
 
@@ -332,12 +320,12 @@ impl<'a> UnalignedMemoryMapping<'a> {
         access_type: AccessType,
         vm_addr: u64,
     ) -> Result<(usize, &MemoryRegion), EbpfError> {
-        if let Some((region_index, region)) = self.find_region(vm_addr) {
+        if let Some((index, region)) = self.find_region(vm_addr) {
             if (region.vm_addr..region.vm_addr_end).contains(&vm_addr)
                 && (access_type == AccessType::Load
                     || ensure_writable_region(region, &self.access_violation_handler))
             {
-                return Ok((region_index, region));
+                return Ok((index, region));
             }
         }
         Err(
@@ -430,11 +418,10 @@ impl<'a> AlignedMemoryMapping<'a> {
 
     /// Given a list of regions translate from virtual machine to host address
     pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64) -> ProgramResult {
-        let index = vm_addr
-            .checked_shr(ebpf::VIRTUAL_ADDRESS_BITS as u32)
-            .unwrap_or(0) as usize;
+        let index = vm_addr.wrapping_shr(ebpf::VIRTUAL_ADDRESS_BITS as u32) as usize;
         if (1..self.regions.len()).contains(&index) {
-            let region = &self.regions[index];
+            // Safety: bounds check above
+            let region = unsafe { self.regions.get_unchecked(index) };
             if access_type == AccessType::Load
                 || ensure_writable_region(region, &self.access_violation_handler)
             {
@@ -452,11 +439,10 @@ impl<'a> AlignedMemoryMapping<'a> {
         access_type: AccessType,
         vm_addr: u64,
     ) -> Result<(usize, &MemoryRegion), EbpfError> {
-        let index = vm_addr
-            .checked_shr(ebpf::VIRTUAL_ADDRESS_BITS as u32)
-            .unwrap_or(0) as usize;
+        let index = vm_addr.wrapping_shr(ebpf::VIRTUAL_ADDRESS_BITS as u32) as usize;
         if (1..self.regions.len()).contains(&index) {
-            let region = &self.regions[index];
+            // Safety: bounds check above
+            let region = unsafe { self.regions.get_unchecked(index) };
             if (region.vm_addr..region.vm_addr_end).contains(&vm_addr)
                 && (access_type == AccessType::Load
                     || ensure_writable_region(region, &self.access_violation_handler))

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -266,11 +266,12 @@ impl<'a> UnalignedMemoryMapping<'a> {
     }
 
     #[allow(clippy::arithmetic_side_effects)]
-    fn find_region(
-        &self,
-        cache: &mut MappingCache,
-        vm_addr: u64,
-    ) -> Option<(usize, &MemoryRegion)> {
+    fn find_region(&self, vm_addr: u64) -> Option<(usize, &MemoryRegion)> {
+        // Safety:
+        // &mut references to the mapping cache are only created internally from methods that do not
+        // invoke each other. UnalignedMemoryMapping is !Sync, so the cache reference below is
+        // guaranteed to be unique.
+        let cache = unsafe { &mut *self.cache.get() };
         if let Some(index) = cache.find(vm_addr) {
             // Safety:
             // Cached index, we validated it before caching it. See the corresponding safety section
@@ -301,13 +302,7 @@ impl<'a> UnalignedMemoryMapping<'a> {
 
     /// Given a list of regions translate from virtual machine to host address
     pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64) -> ProgramResult {
-        // Safety:
-        // &mut references to the mapping cache are only created internally from methods that do not
-        // invoke each other. UnalignedMemoryMapping is !Sync, so the cache reference below is
-        // guaranteed to be unique.
-        let cache = unsafe { &mut *self.cache.get() };
-
-        let region = match self.find_region(cache, vm_addr) {
+        let region = match self.find_region(vm_addr) {
             Some((_region_index, region)) => region,
             None => {
                 return generate_access_violation(
@@ -337,12 +332,7 @@ impl<'a> UnalignedMemoryMapping<'a> {
         access_type: AccessType,
         vm_addr: u64,
     ) -> Result<(usize, &MemoryRegion), EbpfError> {
-        // Safety:
-        // &mut references to the mapping cache are only created internally from methods that do not
-        // invoke each other. UnalignedMemoryMapping is !Sync, so the cache reference below is
-        // guaranteed to be unique.
-        let cache = unsafe { &mut *self.cache.get() };
-        if let Some((region_index, region)) = self.find_region(cache, vm_addr) {
+        if let Some((region_index, region)) = self.find_region(vm_addr) {
             if (region.vm_addr..region.vm_addr_end).contains(&vm_addr)
                 && (access_type == AccessType::Load
                     || ensure_writable_region(region, &self.access_violation_handler))

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -416,12 +416,20 @@ impl<'a> AlignedMemoryMapping<'a> {
         )
     }
 
-    /// Given a list of regions translate from virtual machine to host address
-    pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64) -> ProgramResult {
+    #[inline]
+    fn find_region(&self, vm_addr: u64) -> Option<(usize, &MemoryRegion)> {
         let index = vm_addr.wrapping_shr(ebpf::VIRTUAL_ADDRESS_BITS as u32) as usize;
         if (1..self.regions.len()).contains(&index) {
             // Safety: bounds check above
             let region = unsafe { self.regions.get_unchecked(index) };
+            return Some((index, region));
+        }
+        None
+    }
+
+    /// Given a list of regions translate from virtual machine to host address
+    pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64) -> ProgramResult {
+        if let Some((_index, region)) = self.find_region(vm_addr) {
             if access_type == AccessType::Load
                 || ensure_writable_region(region, &self.access_violation_handler)
             {
@@ -439,10 +447,7 @@ impl<'a> AlignedMemoryMapping<'a> {
         access_type: AccessType,
         vm_addr: u64,
     ) -> Result<(usize, &MemoryRegion), EbpfError> {
-        let index = vm_addr.wrapping_shr(ebpf::VIRTUAL_ADDRESS_BITS as u32) as usize;
-        if (1..self.regions.len()).contains(&index) {
-            // Safety: bounds check above
-            let region = unsafe { self.regions.get_unchecked(index) };
+        if let Some((index, region)) = self.find_region(vm_addr) {
             if (region.vm_addr..region.vm_addr_end).contains(&vm_addr)
                 && (access_type == AccessType::Load
                     || ensure_writable_region(region, &self.access_violation_handler))

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -443,7 +443,7 @@ fn test_owned_ro_region_no_initial_gap() {
     let ro_section =
         ElfExecutable::parse_ro_sections(&config, &SBPFVersion::V0, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let mut memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
     let owned_section = match &ro_section {
         Section::Owned(_offset, data) => data.as_slice(),
         _ => panic!(),
@@ -493,7 +493,7 @@ fn test_owned_ro_region_initial_gap_mappable() {
     let ro_section =
         ElfExecutable::parse_ro_sections(&config, &SBPFVersion::V0, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let mut memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
     let owned_section = match &ro_section {
         Section::Owned(_offset, data) => data.as_slice(),
         _ => panic!(),
@@ -545,7 +545,7 @@ fn test_owned_ro_region_initial_gap_map_error() {
         _ => panic!(),
     };
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let mut memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
 
     // s1 starts at sh_addr=10 so [MM_RODATA_START..MM_RODATA_START + 10] is not mappable
 
@@ -654,7 +654,8 @@ fn test_borrowed_ro_region_no_initial_gap() {
         let ro_section =
             ElfExecutable::parse_ro_sections(&config, &sbpf_version, sections, &elf_bytes).unwrap();
         let ro_region = get_ro_region(&ro_section, &elf_bytes);
-        let memory_mapping = MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
+        let mut memory_mapping =
+            MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
 
         // s1 starts at sh_offset=0 so [0..s2.sh_offset + s2.sh_size]
         // is the valid ro memory area
@@ -695,7 +696,8 @@ fn test_borrowed_ro_region_initial_gap() {
         let ro_section =
             ElfExecutable::parse_ro_sections(&config, &sbpf_version, sections, &elf_bytes).unwrap();
         let ro_region = get_ro_region(&ro_section, &elf_bytes);
-        let memory_mapping = MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
+        let mut memory_mapping =
+            MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
 
         // s2 starts at sh_addr=10 so [0..10] is not mappable
 

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -443,7 +443,7 @@ fn test_owned_ro_region_no_initial_gap() {
     let ro_section =
         ElfExecutable::parse_ro_sections(&config, &SBPFVersion::V0, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let mut memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
     let owned_section = match &ro_section {
         Section::Owned(_offset, data) => data.as_slice(),
         _ => panic!(),
@@ -493,7 +493,7 @@ fn test_owned_ro_region_initial_gap_mappable() {
     let ro_section =
         ElfExecutable::parse_ro_sections(&config, &SBPFVersion::V0, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let mut memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
     let owned_section = match &ro_section {
         Section::Owned(_offset, data) => data.as_slice(),
         _ => panic!(),
@@ -545,7 +545,7 @@ fn test_owned_ro_region_initial_gap_map_error() {
         _ => panic!(),
     };
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let mut memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
 
     // s1 starts at sh_addr=10 so [MM_RODATA_START..MM_RODATA_START + 10] is not mappable
 
@@ -654,8 +654,7 @@ fn test_borrowed_ro_region_no_initial_gap() {
         let ro_section =
             ElfExecutable::parse_ro_sections(&config, &sbpf_version, sections, &elf_bytes).unwrap();
         let ro_region = get_ro_region(&ro_section, &elf_bytes);
-        let mut memory_mapping =
-            MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
+        let memory_mapping = MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
 
         // s1 starts at sh_offset=0 so [0..s2.sh_offset + s2.sh_size]
         // is the valid ro memory area
@@ -696,8 +695,7 @@ fn test_borrowed_ro_region_initial_gap() {
         let ro_section =
             ElfExecutable::parse_ro_sections(&config, &sbpf_version, sections, &elf_bytes).unwrap();
         let ro_region = get_ro_region(&ro_section, &elf_bytes);
-        let mut memory_mapping =
-            MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
+        let memory_mapping = MemoryMapping::new(vec![ro_region], &config, sbpf_version).unwrap();
 
         // s2 starts at sh_addr=10 so [0..10] is not mappable
 


### PR DESCRIPTION
Currently the `MemoryCowCallback` is only invoked when an access is completely contained within a region marked as CoW. Furthermore, it automatically removes the CoW marking and the region will become a normal writable region, meaning the next access will not invoke the `MemoryCowCallback` anymore.

This PR switches to a model which is closer to `SIGSEGV` in other operating systems: It is invoked on every failed access and the handler the access type, location and length passed in and is also responsible for adjusting the memory regions. The memory region which has the next lowest starting virtual address, as well as the virtual address space available to that region, is also supplied as that is typically of interest and has been found already.