### PR TITLE
Pass instruction data area to r2

### DIFF
--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -144,14 +144,14 @@ fn bench_jit_vs_interpreter_address_translation(bencher: &mut Bencher) {
 
 #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
 static ADDRESS_TRANSLATION_STACK_CODE: &str = "
-    mov r1, r2
+    mov r1, r5
     and r1, 4095
     mov r3, r10
     sub r3, r1
     add r3, -1
     ldxb r4, [r3]
-    add r2, 1
-    jlt r2, 0x10000, -8
+    add r5, 1
+    jlt r5, 0x10000, -8
     exit";
 
 #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
@@ -187,10 +187,10 @@ fn bench_jit_vs_interpreter_empty_for_loop(bencher: &mut Bencher) {
     bench_jit_vs_interpreter(
         bencher,
         "
-    mov r1, r2
+    mov r1, r3
     and r1, 1023
-    add r2, 1
-    jlt r2, 0x10000, -4
+    add r3, 1
+    jlt r3, 0x10000, -4
     exit",
         Config::default(),
         262145,

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -49,8 +49,10 @@ pub const MM_RODATA_START: u64 = MM_REGION_SIZE;
 pub const MM_STACK_START: u64 = MM_REGION_SIZE * 2;
 /// Virtual address of the heap region
 pub const MM_HEAP_START: u64 = MM_REGION_SIZE * 3;
-/// Virtual address of the input region
+/// Virtual address of the input region. In ABIv2, this region contains the transaction data.
 pub const MM_INPUT_START: u64 = MM_REGION_SIZE * 4;
+/// Virtual address of the instruction data area (for ABIv2)
+pub const MM_INSTRUCTION_START: u64 = MM_REGION_SIZE * 6;
 
 // eBPF op codes.
 // See also https://www.kernel.org/doc/Documentation/networking/filter.txt

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -343,6 +343,9 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
         debug_assert!(Arc::ptr_eq(&self.loader, executable.get_loader()));
         self.registers[1] = ebpf::MM_INPUT_START;
         self.registers[11] = executable.get_entrypoint_instruction_offset() as u64;
+        if executable.get_sbpf_version() >= SBPFVersion::V4 {
+            self.registers[2] = ebpf::MM_INSTRUCTION_START;
+        }
         let config = executable.get_config();
         let initial_insn_count = self.context_object_pointer.get_remaining();
         self.previous_instruction_meter = initial_insn_count;

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3438,6 +3438,39 @@ fn test_capped_after_callx() {
     );
 }
 
+#[test]
+fn test_input_registers() {
+    // Ensure we've set the input registers with the correct values.
+    let config = Config {
+        enabled_sbpf_versions: SBPFVersion::V4..=SBPFVersion::V4,
+        ..Config::default()
+    };
+    test_interpreter_and_jit_asm!(
+        "
+        mov64 r0, 0
+        mov64 r3, r1
+        and32 r3, -1
+        jne r3, 0, +10
+        mov64 r3, r1
+        arsh64 r3, 32
+        jne r3, 0x4, +7
+        mov64 r3, r2
+        and32 r3, -1
+        jne r3, 0, +4
+        mov64 r3, r2
+        arsh64 r3, 32
+        jne r3, 0x6, +1
+        return
+        mov64 r0, 2
+        return
+        exit",
+        config,
+        [],
+        TestContextObject::new(14),
+        ProgramResult::Ok(0),
+    );
+}
+
 // SBPFv0 only [DEPRECATED]
 
 #[test]


### PR DESCRIPTION
Since we are splitting the transaction data are and the instruction data are, this PR implements what I mentioned in https://github.com/solana-foundation/solana-improvement-documents/pull/177#discussion_r2112475704. We'll pass the address to the instruction area in the R2 register.