### PR TITLE
Remove debug_assert from `MemoryMapping::new_with_cow`

### DIFF
--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -720,14 +720,6 @@ impl<'a> MemoryMapping<'a> {
         sbpf_version: SBPFVersion,
         cow_cb: MemoryCowCallback,
     ) -> Result<Self, EbpfError> {
-        #[cfg(test)]
-        {
-            debug_assert!(
-                sbpf_version != SBPFVersion::V4 || config.aligned_memory_mapping,
-                "SBPFv4 only supports aligned memory"
-            );
-        }
-
         if sbpf_version == SBPFVersion::V4 || config.aligned_memory_mapping {
             AlignedMemoryMapping::new_with_cow(regions, config, sbpf_version, cow_cb)
                 .map(MemoryMapping::Aligned)
@@ -1802,7 +1794,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "SBPFv4 only supports aligned memory")]
     fn v4_aligned_mapping() {
         let config = Config {
             aligned_memory_mapping: false,


### PR DESCRIPTION
**Problem**

The debug assert hinders testing in the monorepo, since we hit the condition frequently when direct mapping is enabled with SBFPv4.

**Solution**

Completely remove the `debug_assert!`