### PR TITLE
Refactor - Skip function registry lookup in SBPFv3

### DIFF
--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -118,7 +118,7 @@ fn test_code_length_estimate() {
                     opcode = 0x85;
                     (0x00, Some(0x91020CDD))
                 }
-                0xF5 => {
+                0xF5 if !sbpf_version.static_syscalls() => {
                     // Put invalid function calls on a separate loop iteration
                     opcode = 0x85;
                     (0x00, Some(0x91020CD0))


### PR DESCRIPTION
In SBPFv3 the internal function registry is an identity mapping and all function calls are verified ahead of time. Thus there is no purpose of doing the lookup anymore. The PR also splits the combined code path in separate ones for SBPFv3 and below.