### PR TITLE
Do not assign initial value to R1 in `execute_program`

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -351,7 +351,6 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
         interpreted: bool,
     ) -> (u64, ProgramResult) {
         debug_assert!(Arc::ptr_eq(&self.loader, executable.get_loader()));
-        self.registers[1] = ebpf::MM_INPUT_START;
         self.registers[11] = executable.get_entrypoint_instruction_offset() as u64;
         let config = executable.get_config();
         let initial_insn_count = self.context_object_pointer.get_remaining();

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -265,6 +265,7 @@ macro_rules! create_vm {
             memory_mapping,
             stack_len,
         );
+        $vm_name.registers[1] = solana_sbpf::ebpf::MM_INPUT_START;
     };
 }
 
@@ -299,6 +300,7 @@ macro_rules! test_interpreter_and_jit {
                 vec![mem_region],
                 None
             );
+            vm.registers[1] = ebpf::MM_INPUT_START;
             let (instruction_count_interpreter, result_interpreter) = vm.execute_program(&$executable, true);
             (
                 instruction_count_interpreter,
@@ -325,6 +327,7 @@ macro_rules! test_interpreter_and_jit {
             match compilation_result {
                 Err(_) => panic!("{:?}", compilation_result),
                 Ok(()) => {
+                    vm.registers[1] = ebpf::MM_INPUT_START;
                     let (instruction_count_jit, result_jit) = vm.execute_program(&$executable, false);
                     let tracer_jit = &vm.context_object_pointer;
                     let mut diverged = false;

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -79,10 +79,11 @@ fn test_verifier_success() {
     )
     .unwrap();
     executable.verify::<TautologyVerifier>().unwrap();
+    let mut context_object = TestContextObject::default();
     create_vm!(
         _vm,
         &executable,
-        &mut TestContextObject::default(),
+        &mut context_object,
         stack,
         heap,
         Vec::new(),


### PR DESCRIPTION
**Problem**

In ABIv2, we want registers to hold the addresses for the transaction area and the instruction area at initialization. This is better done when we permit their initialization to be done in the monorepo.

**Solution**

1. Do not assign a value for register R1 at `fn execute_program`