### PR TITLE
Fix - Turns the bounds check of `e_entry` from inclusive to exclusive

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -495,10 +495,12 @@ impl<C: ContextObject> Executable<C> {
             rodata_header.file_range().unwrap_or_default(),
         );
 
-        if !bytecode_header
-            .vm_range()
-            .contains(&file_header.e_entry.saturating_add(ebpf::INSN_SIZE as u64))
-            || file_header.e_entry.checked_rem(ebpf::INSN_SIZE as u64) != Some(0)
+        if !bytecode_header.vm_range().contains(
+            &file_header
+                .e_entry
+                .saturating_add(ebpf::INSN_SIZE as u64)
+                .saturating_sub(1),
+        ) || file_header.e_entry.checked_rem(ebpf::INSN_SIZE as u64) != Some(0)
         {
             return Err(ElfParserError::InvalidFileHeader);
         }


### PR DESCRIPTION
This technically does not make a difference since every program directly ending in the entrypoint as function start is invalid anyway, because it is missing a `return` at the end.