### PR TITLE
[feature] Add `second_opcode` field to `X86Instruction` to optimize execution efficiency

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -737,7 +737,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 // BPF_JMP class
                 ebpf::JA         => {
                     self.emit_validate_and_profile_instruction_count(Some(target_pc));
-                    // self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64)); //unused ins
+                    self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64));
                     let jump_offset = self.relative_to_target_pc(target_pc, 5);
                     self.emit_ins(X86Instruction::jump_immediate(jump_offset));
                 },
@@ -1217,7 +1217,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         } else { // Arithmetic
             self.emit_ins(X86Instruction::cmp(OperandSize::S64, first_operand, second_operand, None));
         }
-        // self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64)); //unused ins
+        self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64));
         let jump_offset = self.relative_to_target_pc(target_pc, 6);
         self.emit_ins(X86Instruction::conditional_jump_immediate(op, jump_offset));
         self.emit_undo_profile_instruction_count(target_pc);
@@ -1237,7 +1237,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         } else { // Arithmetic
             self.emit_ins(X86Instruction::cmp_immediate(OperandSize::S64, second_operand, immediate, None));
         }
-        // self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64)); //unused ins
+        self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64));
         let jump_offset = self.relative_to_target_pc(target_pc, 6);
         self.emit_ins(X86Instruction::conditional_jump_immediate(op, jump_offset));
         self.emit_undo_profile_instruction_count(target_pc);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -737,7 +737,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 // BPF_JMP class
                 ebpf::JA         => {
                     self.emit_validate_and_profile_instruction_count(Some(target_pc));
-                    self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64));
+                    // self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64)); //unused ins
                     let jump_offset = self.relative_to_target_pc(target_pc, 5);
                     self.emit_ins(X86Instruction::jump_immediate(jump_offset));
                 },
@@ -1217,7 +1217,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         } else { // Arithmetic
             self.emit_ins(X86Instruction::cmp(OperandSize::S64, first_operand, second_operand, None));
         }
-        self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64));
+        // self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64)); //unused ins
         let jump_offset = self.relative_to_target_pc(target_pc, 6);
         self.emit_ins(X86Instruction::conditional_jump_immediate(op, jump_offset));
         self.emit_undo_profile_instruction_count(target_pc);
@@ -1237,7 +1237,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         } else { // Arithmetic
             self.emit_ins(X86Instruction::cmp_immediate(OperandSize::S64, second_operand, immediate, None));
         }
-        self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64));
+        // self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, target_pc as i64)); //unused ins
         let jump_offset = self.relative_to_target_pc(target_pc, 6);
         self.emit_ins(X86Instruction::conditional_jump_immediate(op, jump_offset));
         self.emit_undo_profile_instruction_count(target_pc);

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -511,13 +511,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 ebpf::ADD32_IMM  => {
                     self.emit_sanitized_alu(OperandSize::S32, 0x01, 0, dst, insn.imm);
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::ADD32_REG  => {
-                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x01, src, dst, None));
+                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x01, None, src, dst, None));
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::SUB32_IMM  => {
@@ -530,13 +530,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                         self.emit_sanitized_alu(OperandSize::S32, 0x29, 5, dst, insn.imm);
                     }
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::SUB32_REG  => {
-                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x29, src, dst, None));
+                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x29, None, src, dst, None));
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::MUL32_IMM | ebpf::DIV32_IMM | ebpf::MOD32_IMM if !self.executable.get_sbpf_version().enable_pqr() =>
@@ -562,9 +562,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(Some(dst), Value::RegisterPlusConstant64(src, insn.off as i64, true), 2, None);
                 },
                 ebpf::OR32_IMM   => self.emit_sanitized_alu(OperandSize::S32, 0x09, 1, dst, insn.imm),
-                ebpf::OR32_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x09, src, dst, None)),
+                ebpf::OR32_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x09, None, src, dst, None)),
                 ebpf::AND32_IMM  => self.emit_sanitized_alu(OperandSize::S32, 0x21, 4, dst, insn.imm),
-                ebpf::AND32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x21, src, dst, None)),
+                ebpf::AND32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x21, None, src, dst, None)),
                 ebpf::LSH32_IMM  => self.emit_shift(OperandSize::S32, 4, REGISTER_SCRATCH, dst, Some(insn.imm)),
                 ebpf::LSH32_REG  => self.emit_shift(OperandSize::S32, 4, src, dst, None),
                 ebpf::RSH32_IMM  => self.emit_shift(OperandSize::S32, 5, REGISTER_SCRATCH, dst, Some(insn.imm)),
@@ -577,7 +577,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(Some(dst), Value::RegisterPlusConstant64(src, insn.off as i64, true), 8, None);
                 },
                 ebpf::XOR32_IMM  => self.emit_sanitized_alu(OperandSize::S32, 0x31, 6, dst, insn.imm),
-                ebpf::XOR32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x31, src, dst, None)),
+                ebpf::XOR32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x31, None, src, dst, None)),
                 ebpf::MOV32_IMM  => {
                     if self.should_sanitize_constant(insn.imm) {
                         self.emit_sanitized_load_immediate(dst, insn.imm as u32 as u64 as i64);
@@ -624,7 +624,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
 
                 // BPF_ALU64_STORE class
                 ebpf::ADD64_IMM  => self.emit_sanitized_alu(OperandSize::S64, 0x01, 0, dst, insn.imm),
-                ebpf::ADD64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, src, dst, None)),
+                ebpf::ADD64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, src, dst, None)),
                 ebpf::SUB64_IMM  => {
                     if self.executable.get_sbpf_version().swap_sub_reg_imm_operands() {
                         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0xf7, 3, dst, 0, None));
@@ -635,7 +635,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                         self.emit_sanitized_alu(OperandSize::S64, 0x29, 5, dst, insn.imm);
                     }
                 }
-                ebpf::SUB64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, src, dst, None)),
+                ebpf::SUB64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, src, dst, None)),
                 ebpf::MUL64_IMM | ebpf::DIV64_IMM | ebpf::MOD64_IMM if !self.executable.get_sbpf_version().enable_pqr() =>
                     self.emit_product_quotient_remainder(
                         OperandSize::S64,
@@ -650,7 +650,22 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 ebpf::ST_2B_IMM  if self.executable.get_sbpf_version().move_memory_instruction_classes() => {
                     self.emit_address_translation(None, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, Some(Value::Constant64(insn.imm, true)));
                 },
-                ebpf::MUL64_REG | ebpf::DIV64_REG | ebpf::MOD64_REG if !self.executable.get_sbpf_version().enable_pqr() =>
+                // Replace multiple instructions with a single one 
+                // eg:  BPF_MUL R0, R6
+                // ==> x86:
+                // (old imul encoding: `0100 10XB 1111 0111 :mod 101 r/m`)
+                // (4d 89 e3            mov r11,r12)
+                // (48 52               push rdx)
+                // (49 f7 eb            imul r11)
+                // (5a                  pop rdx)
+                //
+                //  (now imul encoding: `0100 1RXB 0000 1111:1010 1111 : mod qwordreg r/m`)
+                //  in this one, opcode is `0f`, second_opcode is `af`
+                // ==> (4c 0f af c4     imul rax r12)
+                ebpf::MUL64_REG if !self.executable.get_sbpf_version().enable_pqr() =>{
+                    self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x0f, Some(0xaf), dst, src, None));
+                },
+                ebpf::DIV64_REG | ebpf::MOD64_REG if !self.executable.get_sbpf_version().enable_pqr() =>
                     self.emit_product_quotient_remainder(
                         OperandSize::S64,
                         (insn.opc & ebpf::BPF_ALU_OP_MASK) == ebpf::BPF_MOD,
@@ -665,9 +680,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(None, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, Some(Value::Register(src)));
                 },
                 ebpf::OR64_IMM   => self.emit_sanitized_alu(OperandSize::S64, 0x09, 1, dst, insn.imm),
-                ebpf::OR64_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, src, dst, None)),
+                ebpf::OR64_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, None, src, dst, None)),
                 ebpf::AND64_IMM  => self.emit_sanitized_alu(OperandSize::S64, 0x21, 4, dst, insn.imm),
-                ebpf::AND64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x21, src, dst, None)),
+                ebpf::AND64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x21, None, src, dst, None)),
                 ebpf::LSH64_IMM  => self.emit_shift(OperandSize::S64, 4, REGISTER_SCRATCH, dst, Some(insn.imm)),
                 ebpf::LSH64_REG  => self.emit_shift(OperandSize::S64, 4, src, dst, None),
                 ebpf::RSH64_IMM  => self.emit_shift(OperandSize::S64, 5, REGISTER_SCRATCH, dst, Some(insn.imm)),
@@ -686,7 +701,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(None, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, Some(Value::Register(src)));
                 },
                 ebpf::XOR64_IMM  => self.emit_sanitized_alu(OperandSize::S64, 0x31, 6, dst, insn.imm),
-                ebpf::XOR64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, src, dst, None)),
+                ebpf::XOR64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, None, src, dst, None)),
                 ebpf::MOV64_IMM  => {
                     if self.should_sanitize_constant(insn.imm) {
                         self.emit_sanitized_load_immediate(dst, insn.imm);
@@ -907,7 +922,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         } else if destination != REGISTER_SCRATCH {
             self.emit_ins(X86Instruction::load_immediate(destination, value.wrapping_sub(self.immediate_value_key)));
             self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, self.immediate_value_key));
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, destination, None)); // wrapping_add(immediate_value_key)
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, destination, None)); // wrapping_add(immediate_value_key)
         } else {
             let upper_key = (self.immediate_value_key >> 32) as i32 as i64;
             self.emit_ins(X86Instruction::load_immediate(destination, value.wrapping_sub(lower_key).rotate_right(32).wrapping_sub(upper_key)));
@@ -920,12 +935,12 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
     fn emit_sanitized_alu(&mut self, size: OperandSize, opcode: u8, opcode_extension: u8, destination: X86Register, immediate: i64) {
         if self.should_sanitize_constant(immediate) {
             self.emit_sanitized_load_immediate(REGISTER_SCRATCH, immediate);
-            self.emit_ins(X86Instruction::alu(size, opcode, REGISTER_SCRATCH, destination, None));
+            self.emit_ins(X86Instruction::alu(size, opcode, None, REGISTER_SCRATCH, destination, None));
         } else if immediate >= i32::MIN as i64 && immediate <= i32::MAX as i64 {
             self.emit_ins(X86Instruction::alu_immediate(size, 0x81, opcode_extension, destination, immediate, None));
         } else {
             self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, immediate));
-            self.emit_ins(X86Instruction::alu(size, opcode, REGISTER_SCRATCH, destination, None));
+            self.emit_ins(X86Instruction::alu(size, opcode, None, REGISTER_SCRATCH, destination, None));
         }
     }
 
@@ -938,11 +953,11 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::cycle_count()); // rdtsc
         self.emit_ins(X86Instruction::fence(FenceType::Load)); // lfence
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0xc1, 4, RDX, 32, None)); // RDX <<= 32;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, RDX, RAX, None)); // RAX |= RDX;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, None, RDX, RAX, None)); // RAX |= RDX;
         if begin {
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator -= RAX;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator -= RAX;
         } else {
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator += RAX;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator += RAX;
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, REGISTER_PTR_TO_VM, 1, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchDenominator))))); // *denominator += 1;
         }
         self.emit_ins(X86Instruction::pop(RAX));
@@ -972,7 +987,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 self.emit_sanitized_alu(OperandSize::S64, 0x01, 0, REGISTER_INSTRUCTION_METER, target_pc as i64 - self.pc as i64 - 1); // instruction_meter += target_pc - (self.pc + 1);
             },
             None => {
-                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += target_pc;
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += target_pc;
                 self.emit_sanitized_alu(OperandSize::S64, 0x81, 5, REGISTER_INSTRUCTION_METER, self.pc as i64 + 1); // instruction_meter -= self.pc + 1;
             },
         }
@@ -1054,7 +1069,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, offset, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0))));
                     } else {
                         self.emit_ins(X86Instruction::load_immediate(dst, offset));
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, reg, dst, None));
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, reg, dst, None));
                     }
                 },
                 Value::Constant64(value, user_provided) => {
@@ -1166,7 +1181,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 } else {
                     self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, constant));
                 }
-                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, reg, REGISTER_SCRATCH, None));
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, reg, REGISTER_SCRATCH, None));
             },
             _ => {
                 #[cfg(debug_assertions)]
@@ -1332,7 +1347,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             if signed {
                 self.emit_ins(X86Instruction::sign_extend_rax_rdx(size));
             } else {
-                self.emit_ins(X86Instruction::alu(size, 0x31, RDX, RDX, None)); // RDX = 0
+                self.emit_ins(X86Instruction::alu(size, 0x31, None, RDX, RDX, None)); // RDX = 0
             }
         }
 
@@ -1352,7 +1367,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         }
         if let OperandSize::S32 = size {
             if signed && !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
             }
         }
     }
@@ -1399,9 +1414,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.set_anchor(ANCHOR_EPILOGUE);
         if self.config.enable_instruction_meter {
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 5, REGISTER_INSTRUCTION_METER, 1, None)); // REGISTER_INSTRUCTION_METER -= 1;
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // REGISTER_INSTRUCTION_METER -= pc;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // REGISTER_INSTRUCTION_METER -= pc;
             // *DueInsnCount = *PreviousInstructionMeter - REGISTER_INSTRUCTION_METER;
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2B, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::PreviousInstructionMeter))))); // REGISTER_INSTRUCTION_METER -= *PreviousInstructionMeter;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2B, None, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::PreviousInstructionMeter))))); // REGISTER_INSTRUCTION_METER -= *PreviousInstructionMeter;
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0xf7, 3, REGISTER_INSTRUCTION_METER, 0, None)); // REGISTER_INSTRUCTION_METER = -REGISTER_INSTRUCTION_METER;
             self.emit_ins(X86Instruction::store(OperandSize::S64, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::DueInsnCount)))); // *DueInsnCount = REGISTER_INSTRUCTION_METER;
         }
@@ -1437,7 +1452,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         }
         self.emit_ins(X86Instruction::lea(OperandSize::S64, REGISTER_PTR_TO_VM, REGISTER_SCRATCH, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::ProgramResult)))));
         self.emit_ins(X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], REGISTER_SCRATCH, X86IndirectAccess::Offset(std::mem::size_of::<u64>() as i32))); // result.return_value = R0;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, REGISTER_SCRATCH, REGISTER_SCRATCH, None)); // REGISTER_SCRATCH ^= REGISTER_SCRATCH; // REGISTER_SCRATCH = 0;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, None, REGISTER_SCRATCH, REGISTER_SCRATCH, None)); // REGISTER_SCRATCH ^= REGISTER_SCRATCH; // REGISTER_SCRATCH = 0;
         self.emit_ins(X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
 
         // Handler for exceptions which report their pc
@@ -1541,7 +1556,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::push(REGISTER_MAP[0], None));
         // Calculate offset relative to program_vm_addr
         self.emit_ins(X86Instruction::load_immediate(REGISTER_MAP[0], self.program_vm_addr as i64));
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_MAP[0], REGISTER_SCRATCH, None)); // guest_target_pc = guest_target_address - self.program_vm_addr;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, REGISTER_MAP[0], REGISTER_SCRATCH, None)); // guest_target_pc = guest_target_address - self.program_vm_addr;
         // Force alignment of guest_target_pc
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 4, REGISTER_SCRATCH, !(INSN_SIZE as i64 - 1), None)); // guest_target_pc &= !(INSN_SIZE - 1);
         // Bound check
@@ -1562,13 +1577,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::conditional_jump_immediate(0x85, self.relative_to_anchor(ANCHOR_CALL_REG_UNSUPPORTED_INSTRUCTION, 6))); // If host_target_address & (1 << 31) != 0, throw UnsupportedInstruction
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S32, 0x81, 4, REGISTER_MAP[0], i32::MAX as i64, None)); // host_target_address &= (1 << 31) - 1;
         // A version of `self.emit_profile_instruction_count(None);` which reads self.pc from the stack
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2b, REGISTER_INSTRUCTION_METER, RSP, Some(X86IndirectAccess::OffsetIndexShift(-8, RSP, 0)))); // instruction_meter -= guest_current_pc;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2b, None, REGISTER_INSTRUCTION_METER, RSP, Some(X86IndirectAccess::OffsetIndexShift(-8, RSP, 0)))); // instruction_meter -= guest_current_pc;
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 5, REGISTER_INSTRUCTION_METER, 1, None)); // instruction_meter -= 1;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += guest_target_pc;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += guest_target_pc;
         // Offset host_target_address by self.result.text_section
         self.emit_ins(X86Instruction::mov_mmx(OperandSize::S64, REGISTER_SCRATCH, MM0));
         self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, self.result.text_section.as_ptr() as i64)); // REGISTER_SCRATCH = self.result.text_section;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_MAP[0], None)); // host_target_address += self.result.text_section;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, REGISTER_MAP[0], None)); // host_target_address += self.result.text_section;
         self.emit_ins(X86Instruction::mov_mmx(OperandSize::S64, MM0, REGISTER_SCRATCH));
         // Restore the clobbered REGISTER_MAP[0]
         self.emit_ins(X86Instruction::xchg(OperandSize::S64, REGISTER_MAP[0], RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0)))); // Swap REGISTER_MAP[0] and host_target_address

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -511,13 +511,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 ebpf::ADD32_IMM  => {
                     self.emit_sanitized_alu(OperandSize::S32, 0x01, 0, dst, insn.imm);
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::ADD32_REG  => {
-                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x01, None, src, dst, None));
+                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x01, src, dst, None));
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::SUB32_IMM  => {
@@ -530,13 +530,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                         self.emit_sanitized_alu(OperandSize::S32, 0x29, 5, dst, insn.imm);
                     }
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::SUB32_REG  => {
-                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x29, None, src, dst, None));
+                    self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x29, src, dst, None));
                     if !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
                     }
                 },
                 ebpf::MUL32_IMM | ebpf::DIV32_IMM | ebpf::MOD32_IMM if !self.executable.get_sbpf_version().enable_pqr() =>
@@ -562,9 +562,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(Some(dst), Value::RegisterPlusConstant64(src, insn.off as i64, true), 2, None);
                 },
                 ebpf::OR32_IMM   => self.emit_sanitized_alu(OperandSize::S32, 0x09, 1, dst, insn.imm),
-                ebpf::OR32_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x09, None, src, dst, None)),
+                ebpf::OR32_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x09, src, dst, None)),
                 ebpf::AND32_IMM  => self.emit_sanitized_alu(OperandSize::S32, 0x21, 4, dst, insn.imm),
-                ebpf::AND32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x21, None, src, dst, None)),
+                ebpf::AND32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x21, src, dst, None)),
                 ebpf::LSH32_IMM  => self.emit_shift(OperandSize::S32, 4, REGISTER_SCRATCH, dst, Some(insn.imm)),
                 ebpf::LSH32_REG  => self.emit_shift(OperandSize::S32, 4, src, dst, None),
                 ebpf::RSH32_IMM  => self.emit_shift(OperandSize::S32, 5, REGISTER_SCRATCH, dst, Some(insn.imm)),
@@ -577,7 +577,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(Some(dst), Value::RegisterPlusConstant64(src, insn.off as i64, true), 8, None);
                 },
                 ebpf::XOR32_IMM  => self.emit_sanitized_alu(OperandSize::S32, 0x31, 6, dst, insn.imm),
-                ebpf::XOR32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x31, None, src, dst, None)),
+                ebpf::XOR32_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S32, 0x31, src, dst, None)),
                 ebpf::MOV32_IMM  => {
                     if self.should_sanitize_constant(insn.imm) {
                         self.emit_sanitized_load_immediate(dst, insn.imm as u32 as u64 as i64);
@@ -624,7 +624,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
 
                 // BPF_ALU64_STORE class
                 ebpf::ADD64_IMM  => self.emit_sanitized_alu(OperandSize::S64, 0x01, 0, dst, insn.imm),
-                ebpf::ADD64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, src, dst, None)),
+                ebpf::ADD64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, src, dst, None)),
                 ebpf::SUB64_IMM  => {
                     if self.executable.get_sbpf_version().swap_sub_reg_imm_operands() {
                         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0xf7, 3, dst, 0, None));
@@ -635,7 +635,10 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                         self.emit_sanitized_alu(OperandSize::S64, 0x29, 5, dst, insn.imm);
                     }
                 }
-                ebpf::SUB64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, src, dst, None)),
+                ebpf::SUB64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, src, dst, None)),
+                // ebpf::MUL64_IMM if !self.executable.get_sbpf_version().enable_pqr() => {
+                //     self.emit_ins(X86Instruction::alu(OperandSize::S64, 0xaf0f, dst, src, None));
+                // },
                 ebpf::MUL64_IMM | ebpf::DIV64_IMM | ebpf::MOD64_IMM if !self.executable.get_sbpf_version().enable_pqr() =>
                     self.emit_product_quotient_remainder(
                         OperandSize::S64,
@@ -650,22 +653,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 ebpf::ST_2B_IMM  if self.executable.get_sbpf_version().move_memory_instruction_classes() => {
                     self.emit_address_translation(None, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, Some(Value::Constant64(insn.imm, true)));
                 },
-                // Replace multiple instructions with a single one 
-                // eg:  BPF_MUL R0, R6
-                // ==> x86:
-                // (old imul encoding: `0100 10XB 1111 0111 :mod 101 r/m`)
-                // (4d 89 e3            mov r11,r12)
-                // (48 52               push rdx)
-                // (49 f7 eb            imul r11)
-                // (5a                  pop rdx)
-                //
-                //  (now imul encoding: `0100 1RXB 0000 1111:1010 1111 : mod qwordreg r/m`)
-                //  in this one, opcode is `0f`, second_opcode is `af`
-                // ==> (4c 0f af c4     imul rax r12)
-                ebpf::MUL64_REG if !self.executable.get_sbpf_version().enable_pqr() =>{
-                    self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x0f, Some(0xaf), dst, src, None));
-                },
-                ebpf::DIV64_REG | ebpf::MOD64_REG if !self.executable.get_sbpf_version().enable_pqr() =>
+                ebpf::MUL64_REG | ebpf::DIV64_REG | ebpf::MOD64_REG if !self.executable.get_sbpf_version().enable_pqr() =>
                     self.emit_product_quotient_remainder(
                         OperandSize::S64,
                         (insn.opc & ebpf::BPF_ALU_OP_MASK) == ebpf::BPF_MOD,
@@ -680,9 +668,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(None, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 2, Some(Value::Register(src)));
                 },
                 ebpf::OR64_IMM   => self.emit_sanitized_alu(OperandSize::S64, 0x09, 1, dst, insn.imm),
-                ebpf::OR64_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, None, src, dst, None)),
+                ebpf::OR64_REG   => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, src, dst, None)),
                 ebpf::AND64_IMM  => self.emit_sanitized_alu(OperandSize::S64, 0x21, 4, dst, insn.imm),
-                ebpf::AND64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x21, None, src, dst, None)),
+                ebpf::AND64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x21, src, dst, None)),
                 ebpf::LSH64_IMM  => self.emit_shift(OperandSize::S64, 4, REGISTER_SCRATCH, dst, Some(insn.imm)),
                 ebpf::LSH64_REG  => self.emit_shift(OperandSize::S64, 4, src, dst, None),
                 ebpf::RSH64_IMM  => self.emit_shift(OperandSize::S64, 5, REGISTER_SCRATCH, dst, Some(insn.imm)),
@@ -701,7 +689,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                     self.emit_address_translation(None, Value::RegisterPlusConstant64(dst, insn.off as i64, true), 8, Some(Value::Register(src)));
                 },
                 ebpf::XOR64_IMM  => self.emit_sanitized_alu(OperandSize::S64, 0x31, 6, dst, insn.imm),
-                ebpf::XOR64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, None, src, dst, None)),
+                ebpf::XOR64_REG  => self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, src, dst, None)),
                 ebpf::MOV64_IMM  => {
                     if self.should_sanitize_constant(insn.imm) {
                         self.emit_sanitized_load_immediate(dst, insn.imm);
@@ -922,7 +910,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         } else if destination != REGISTER_SCRATCH {
             self.emit_ins(X86Instruction::load_immediate(destination, value.wrapping_sub(self.immediate_value_key)));
             self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, self.immediate_value_key));
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, destination, None)); // wrapping_add(immediate_value_key)
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, destination, None)); // wrapping_add(immediate_value_key)
         } else {
             let upper_key = (self.immediate_value_key >> 32) as i32 as i64;
             self.emit_ins(X86Instruction::load_immediate(destination, value.wrapping_sub(lower_key).rotate_right(32).wrapping_sub(upper_key)));
@@ -932,15 +920,15 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         }
     }
 
-    fn emit_sanitized_alu(&mut self, size: OperandSize, opcode: u8, opcode_extension: u8, destination: X86Register, immediate: i64) {
+    fn emit_sanitized_alu(&mut self, size: OperandSize, opcode: u16, opcode_extension: u8, destination: X86Register, immediate: i64) {
         if self.should_sanitize_constant(immediate) {
             self.emit_sanitized_load_immediate(REGISTER_SCRATCH, immediate);
-            self.emit_ins(X86Instruction::alu(size, opcode, None, REGISTER_SCRATCH, destination, None));
+            self.emit_ins(X86Instruction::alu(size, opcode, REGISTER_SCRATCH, destination, None));
         } else if immediate >= i32::MIN as i64 && immediate <= i32::MAX as i64 {
             self.emit_ins(X86Instruction::alu_immediate(size, 0x81, opcode_extension, destination, immediate, None));
         } else {
             self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, immediate));
-            self.emit_ins(X86Instruction::alu(size, opcode, None, REGISTER_SCRATCH, destination, None));
+            self.emit_ins(X86Instruction::alu(size, opcode, REGISTER_SCRATCH, destination, None));
         }
     }
 
@@ -953,11 +941,11 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::cycle_count()); // rdtsc
         self.emit_ins(X86Instruction::fence(FenceType::Load)); // lfence
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0xc1, 4, RDX, 32, None)); // RDX <<= 32;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, None, RDX, RAX, None)); // RAX |= RDX;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x09, RDX, RAX, None)); // RAX |= RDX;
         if begin {
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator -= RAX;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator -= RAX;
         } else {
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator += RAX;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, RAX, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchNumerator))))); // *numerator += RAX;
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, REGISTER_PTR_TO_VM, 1, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::StopwatchDenominator))))); // *denominator += 1;
         }
         self.emit_ins(X86Instruction::pop(RAX));
@@ -987,7 +975,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 self.emit_sanitized_alu(OperandSize::S64, 0x01, 0, REGISTER_INSTRUCTION_METER, target_pc as i64 - self.pc as i64 - 1); // instruction_meter += target_pc - (self.pc + 1);
             },
             None => {
-                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += target_pc;
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += target_pc;
                 self.emit_sanitized_alu(OperandSize::S64, 0x81, 5, REGISTER_INSTRUCTION_METER, self.pc as i64 + 1); // instruction_meter -= self.pc + 1;
             },
         }
@@ -1069,7 +1057,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, offset, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0))));
                     } else {
                         self.emit_ins(X86Instruction::load_immediate(dst, offset));
-                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, reg, dst, None));
+                        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, reg, dst, None));
                     }
                 },
                 Value::Constant64(value, user_provided) => {
@@ -1181,7 +1169,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 } else {
                     self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, constant));
                 }
-                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, reg, REGISTER_SCRATCH, None));
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, reg, REGISTER_SCRATCH, None));
             },
             _ => {
                 #[cfg(debug_assertions)]
@@ -1222,7 +1210,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         }
     }
 
-    fn emit_conditional_branch_reg(&mut self, op: u8, bitwise: bool, first_operand: X86Register, second_operand: X86Register, target_pc: usize) {
+    fn emit_conditional_branch_reg(&mut self, op: u16, bitwise: bool, first_operand: X86Register, second_operand: X86Register, target_pc: usize) {
         self.emit_validate_and_profile_instruction_count(Some(target_pc));
         if bitwise { // Logical
             self.emit_ins(X86Instruction::test(OperandSize::S64, first_operand, second_operand, None));
@@ -1235,7 +1223,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_undo_profile_instruction_count(target_pc);
     }
 
-    fn emit_conditional_branch_imm(&mut self, op: u8, bitwise: bool, immediate: i64, second_operand: X86Register, target_pc: usize) {
+    fn emit_conditional_branch_imm(&mut self, op: u16, bitwise: bool, immediate: i64, second_operand: X86Register, target_pc: usize) {
         self.emit_validate_and_profile_instruction_count(Some(target_pc));
         if self.should_sanitize_constant(immediate) {
             self.emit_sanitized_load_immediate(REGISTER_SCRATCH, immediate);
@@ -1347,7 +1335,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             if signed {
                 self.emit_ins(X86Instruction::sign_extend_rax_rdx(size));
             } else {
-                self.emit_ins(X86Instruction::alu(size, 0x31, None, RDX, RDX, None)); // RDX = 0
+                self.emit_ins(X86Instruction::alu(size, 0x31, RDX, RDX, None)); // RDX = 0
             }
         }
 
@@ -1367,7 +1355,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         }
         if let OperandSize::S32 = size {
             if signed && !self.executable.get_sbpf_version().explicit_sign_extension_of_results() {
-                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, None, dst, dst, None)); // sign extend i32 to i64
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x63, dst, dst, None)); // sign extend i32 to i64
             }
         }
     }
@@ -1414,9 +1402,9 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.set_anchor(ANCHOR_EPILOGUE);
         if self.config.enable_instruction_meter {
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 5, REGISTER_INSTRUCTION_METER, 1, None)); // REGISTER_INSTRUCTION_METER -= 1;
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // REGISTER_INSTRUCTION_METER -= pc;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // REGISTER_INSTRUCTION_METER -= pc;
             // *DueInsnCount = *PreviousInstructionMeter - REGISTER_INSTRUCTION_METER;
-            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2B, None, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::PreviousInstructionMeter))))); // REGISTER_INSTRUCTION_METER -= *PreviousInstructionMeter;
+            self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2B, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::PreviousInstructionMeter))))); // REGISTER_INSTRUCTION_METER -= *PreviousInstructionMeter;
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0xf7, 3, REGISTER_INSTRUCTION_METER, 0, None)); // REGISTER_INSTRUCTION_METER = -REGISTER_INSTRUCTION_METER;
             self.emit_ins(X86Instruction::store(OperandSize::S64, REGISTER_INSTRUCTION_METER, REGISTER_PTR_TO_VM, X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::DueInsnCount)))); // *DueInsnCount = REGISTER_INSTRUCTION_METER;
         }
@@ -1452,7 +1440,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         }
         self.emit_ins(X86Instruction::lea(OperandSize::S64, REGISTER_PTR_TO_VM, REGISTER_SCRATCH, Some(X86IndirectAccess::Offset(self.slot_in_vm(RuntimeEnvironmentSlot::ProgramResult)))));
         self.emit_ins(X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], REGISTER_SCRATCH, X86IndirectAccess::Offset(std::mem::size_of::<u64>() as i32))); // result.return_value = R0;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, None, REGISTER_SCRATCH, REGISTER_SCRATCH, None)); // REGISTER_SCRATCH ^= REGISTER_SCRATCH; // REGISTER_SCRATCH = 0;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x31, REGISTER_SCRATCH, REGISTER_SCRATCH, None)); // REGISTER_SCRATCH ^= REGISTER_SCRATCH; // REGISTER_SCRATCH = 0;
         self.emit_ins(X86Instruction::jump_immediate(self.relative_to_anchor(ANCHOR_EPILOGUE, 5)));
 
         // Handler for exceptions which report their pc
@@ -1556,7 +1544,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::push(REGISTER_MAP[0], None));
         // Calculate offset relative to program_vm_addr
         self.emit_ins(X86Instruction::load_immediate(REGISTER_MAP[0], self.program_vm_addr as i64));
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, None, REGISTER_MAP[0], REGISTER_SCRATCH, None)); // guest_target_pc = guest_target_address - self.program_vm_addr;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x29, REGISTER_MAP[0], REGISTER_SCRATCH, None)); // guest_target_pc = guest_target_address - self.program_vm_addr;
         // Force alignment of guest_target_pc
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 4, REGISTER_SCRATCH, !(INSN_SIZE as i64 - 1), None)); // guest_target_pc &= !(INSN_SIZE - 1);
         // Bound check
@@ -1577,13 +1565,13 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::conditional_jump_immediate(0x85, self.relative_to_anchor(ANCHOR_CALL_REG_UNSUPPORTED_INSTRUCTION, 6))); // If host_target_address & (1 << 31) != 0, throw UnsupportedInstruction
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S32, 0x81, 4, REGISTER_MAP[0], i32::MAX as i64, None)); // host_target_address &= (1 << 31) - 1;
         // A version of `self.emit_profile_instruction_count(None);` which reads self.pc from the stack
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2b, None, REGISTER_INSTRUCTION_METER, RSP, Some(X86IndirectAccess::OffsetIndexShift(-8, RSP, 0)))); // instruction_meter -= guest_current_pc;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2b, REGISTER_INSTRUCTION_METER, RSP, Some(X86IndirectAccess::OffsetIndexShift(-8, RSP, 0)))); // instruction_meter -= guest_current_pc;
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 5, REGISTER_INSTRUCTION_METER, 1, None)); // instruction_meter -= 1;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += guest_target_pc;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += guest_target_pc;
         // Offset host_target_address by self.result.text_section
         self.emit_ins(X86Instruction::mov_mmx(OperandSize::S64, REGISTER_SCRATCH, MM0));
         self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, self.result.text_section.as_ptr() as i64)); // REGISTER_SCRATCH = self.result.text_section;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, None, REGISTER_SCRATCH, REGISTER_MAP[0], None)); // host_target_address += self.result.text_section;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_MAP[0], None)); // host_target_address += self.result.text_section;
         self.emit_ins(X86Instruction::mov_mmx(OperandSize::S64, MM0, REGISTER_SCRATCH));
         // Restore the clobbered REGISTER_MAP[0]
         self.emit_ins(X86Instruction::xchg(OperandSize::S64, REGISTER_MAP[0], RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0)))); // Swap REGISTER_MAP[0] and host_target_address

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -92,8 +92,7 @@ pub enum FenceType {
 pub struct X86Instruction {
     size: OperandSize,
     opcode_escape_sequence: u8,
-    opcode: u8,
-    second_opcode: Option<u8>, // support second_opcode to optimize
+    opcode: u16, // 0-7 is first opcode, 8-15 is second opcode
     modrm: bool,
     indirect: Option<X86IndirectAccess>,
     first_operand: u8,
@@ -107,7 +106,6 @@ impl X86Instruction {
         size: OperandSize::S0,
         opcode_escape_sequence: 0,
         opcode: 0,
-        second_opcode:None, // support second_opcode to optimize
         modrm: true,
         indirect: None,
         first_operand: 0,
@@ -186,14 +184,12 @@ impl X86Instruction {
             3 => jit.emit::<u16>(0x0f3a),
             _ => {}
         }
-        jit.emit::<u8>(self.opcode);
-        // match if have "second opcode" ?
-        match self.second_opcode {
-            Some(i)=> {
-                jit.emit::<u8>(i);
-            }
-            None => {} 
-        } 
+        // If the high 8 bits are zero
+        if self.opcode >> 8 == 0 {
+            jit.emit::<u8>((self.opcode & 0xFF) as u8);
+        } else {
+            jit.emit::<u16>(self.opcode);
+        }        
         if self.modrm {
             jit.emit::<u8>((modrm.mode << 6) | (modrm.r << 3) | modrm.m);
             let sib = (sib.scale << 6) | (sib.index << 3) | sib.base;
@@ -208,8 +204,7 @@ impl X86Instruction {
     /// Arithmetic or logic
     pub const fn alu(
         size: OperandSize,
-        opcode: u8,
-        second_opcode: Option<u8>,
+        opcode: u16,
         source: X86Register,
         destination: X86Register,
         indirect: Option<X86IndirectAccess>,
@@ -218,7 +213,6 @@ impl X86Instruction {
         Self {
             size,
             opcode,
-            second_opcode,
             first_operand: source as u8,
             second_operand: destination as u8,
             indirect,
@@ -229,7 +223,7 @@ impl X86Instruction {
     /// Arithmetic or logic
     pub const fn alu_immediate(
         size: OperandSize,
-        opcode: u8,
+        opcode: u16,
         opcode_extension: u8,
         destination: X86Register,
         immediate: i64,
@@ -321,7 +315,7 @@ impl X86Instruction {
         Self {
             size,
             opcode_escape_sequence: 1,
-            opcode: condition,
+            opcode: condition as u16,
             first_operand: destination as u8,
             second_operand: source as u8,
             ..Self::DEFAULT
@@ -364,7 +358,7 @@ impl X86Instruction {
             OperandSize::S32 | OperandSize::S64 => Self {
                 size,
                 opcode_escape_sequence: 1,
-                opcode: 0xc8 | ((destination as u8) & 0b111),
+                opcode: 0xc8 | ((destination as u8) & 0b111) as u16,
                 modrm: false,
                 second_operand: destination as u8,
                 ..Self::DEFAULT
@@ -578,7 +572,7 @@ impl X86Instruction {
         // Load full u64 imm into u64 reg
         Self {
             size,
-            opcode: 0xb8 | ((destination as u8) & 0b111),
+            opcode: (0xb8 | ((destination as u8) & 0b111)) as u16,
             modrm: false,
             second_operand: destination as u8,
             immediate_size: size,
@@ -638,7 +632,7 @@ impl X86Instruction {
         if indirect.is_none() {
             Self {
                 size: OperandSize::S32,
-                opcode: 0x50 | ((source as u8) & 0b111),
+                opcode: 0x50 | ((source as u8) & 0b111) as u16,
                 modrm: false,
                 second_operand: source as u8,
                 ..Self::DEFAULT
@@ -660,7 +654,7 @@ impl X86Instruction {
     pub const fn pop(destination: X86Register) -> Self {
         Self {
             size: OperandSize::S32,
-            opcode: 0x58 | ((destination as u8) & 0b111),
+            opcode: 0x58 | ((destination as u8) & 0b111) as u16,
             modrm: false,
             second_operand: destination as u8,
             ..Self::DEFAULT
@@ -668,7 +662,7 @@ impl X86Instruction {
     }
 
     /// Jump to relative destination on condition
-    pub const fn conditional_jump_immediate(opcode: u8, relative_destination: i32) -> Self {
+    pub const fn conditional_jump_immediate(opcode: u16, relative_destination: i32) -> Self {
         Self {
             size: OperandSize::S32,
             opcode_escape_sequence: 1,

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -189,7 +189,7 @@ impl X86Instruction {
             jit.emit::<u8>((self.opcode & 0xFF) as u8);
         } else {
             jit.emit::<u16>(self.opcode);
-        }        
+        }
         if self.modrm {
             jit.emit::<u8>((modrm.mode << 6) | (modrm.r << 3) | modrm.m);
             let sib = (sib.scale << 6) | (sib.index << 3) | sib.base;

--- a/src/x86.rs
+++ b/src/x86.rs
@@ -92,7 +92,7 @@ pub enum FenceType {
 pub struct X86Instruction {
     size: OperandSize,
     opcode_escape_sequence: u8,
-    opcode: u16, // 0-7 is first opcode, 8-15 is second opcode
+    opcode: u16, // lower 8 bits (0–7) are first opcode, upper 8 bits (8–15) are second opcode
     modrm: bool,
     indirect: Option<X86IndirectAccess>,
     first_operand: u8,


### PR DESCRIPTION
Add a new `second_opcode` field in the `X86Instruction` struct.  
The additional opcode allows certain instructions to be represented more compactly, 
which reduces the number of generated x86 instructions during code emission.

 eg:  `BPF_MUL R0, R6`
 ==> x86:
 (old imul encoding: `0100 10XB 1111 0111 :mod 101 r/m`) need 4 instructions to complete this operation.
 (`4d 89 e3          mov r11,r12`)
 (`48 52             push rdx`)
 (`49 f7 eb          imul r11`)
 (`5a                pop rdx`)

  (now imul encoding: `0100 1RXB 0000 1111:1010 1111 : mod qwordreg r/m`) only need 1 instruction!
  in this one, opcode is `0f`, second_opcode is `af`
 ==> (`4c 0f af c4     imul rax r12`)
