### PR TITLE
Refactor/instruction trace dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +94,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +121,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.91",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -145,6 +183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,9 +226,9 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "log"
@@ -321,6 +369,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shuttle"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,11 +414,13 @@ dependencies = [
  "elf",
  "gdbstub",
  "hash32",
+ "hex",
  "json",
  "libc",
  "log",
  "rand",
  "rustc-demangle",
+ "sha2",
  "shuttle",
  "test_utils",
  "thiserror",
@@ -442,6 +503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +528,12 @@ checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 dependencies = [
  "void",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,11 @@ byteorder = "1.2"
 combine = "3.8.1"
 gdbstub = { version = "0.6.2", optional = true }
 hash32 = "0.3.1"
+hex = "0.4"
 log = "0.4.2"
 rand = { version = "0.8.5", features = ["small_rng"], optional = true }
 rustc-demangle = "0.1"
+sha2 = "0.10"
 shuttle = { version = "0.7.1", optional = true }
 thiserror = "2.0.9"
 

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -436,7 +436,11 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
             let digest = Sha256::digest(as_bytes(self.instruction_trace.as_slice()));
             let hex = hex::encode(digest);
             if let Some(file_name) = hex.get(..FILE_NAME_LEN) {
-                let base = std::path::PathBuf::from(vm_trace_dir).join(file_name);
+                let current_dir = std::env::current_dir()?;
+                let vm_trace_dir = current_dir.join(vm_trace_dir);
+                std::fs::create_dir_all(&vm_trace_dir)?;
+
+                let base = vm_trace_dir.join(file_name);
                 let mut regs_file = std::fs::File::create(base.with_extension("regs"))?;
                 let mut insns_file = std::fs::File::create(base.with_extension("insns"))?;
                 let (_vm_addr, program) = executable.get_text_bytes();


### PR DESCRIPTION
The aim of this PR is to respect the VM_TRACE_DIR variable and hence dump the instruction trace in the provided directory.

I've managed to wrap up a working setup with this code on top of `mollusk-svm 0.6.1`. I've only had to silence the lack of the trace method of the ContextObject trait by bringing a dummy back.

Please have a look. I'm not pretty sure if this is the right place for the `AsBytes` trait. I'm also unsure about the possibility of passing an error back if writing of the files fails due to some reason.