### PR TITLE
Advance debug port with nesting level to avoid port reuse in CPIs

### DIFF
--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -132,6 +132,10 @@ impl ContextObject for DummyContextObject {
     fn get_remaining(&self) -> u64 {
         0
     }
+
+    fn get_nesting_level(&self) -> u32 {
+        0
+    }
 }
 
 /// Result of the executable analysis

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -35,6 +35,10 @@ impl ContextObject for TestContextObject {
     fn get_remaining(&self) -> u64 {
         self.remaining
     }
+
+    fn get_nesting_level(&self) -> u32 {
+        0
+    }
 }
 
 impl TestContextObject {


### PR DESCRIPTION
Currently on each program execution the debugger starts listening on $VM_DEBUG_PORT.
This is particularly a problem when there are CPIs as on each CPI another VM is instantiated attempting to reuse $VM_DEBUG_PORT.
This PR aims to address this so that the debugger around the CPI will start listening on $VM_DEBUG_PORT + the nesting level of the current instruction. The idea is to provide predictability at the other end.

The runtime is tightly coupled with SBPF so changes are also needed there. Here are the proposed changes: https://github.com/anza-xyz/agave/commit/8d752f7d09d21a0cec971ae3fed21f2cde96c7d4

While this PR provides a possible fix it is also for provoking a discussion about this problem if there's a more potential solution.

EDIT: Here's another approach that basically allows passing an offset to the debug_port from runtime directly when executing a program:
https://github.com/anza-xyz/agave/commit/e2412098731e2d0a50dab52aedf10d336db1bc1c
Then add this value to the debug_port:
https://github.com/anza-xyz/sbpf/compare/main...procdump:sbpf:debugger_port_offset