### PR TITLE
debugger: Expose debug metadata to the client

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -46,7 +46,7 @@ fn wait_for_tcp(port: u16) -> DynResult<TcpStream> {
 /// Connect to the debugger and hand over the control of the interpreter
 pub fn execute<C: ContextObject>(interpreter: &mut Interpreter<C>, port: u16) {
     if let Some(metadata) = &interpreter.vm.debug_metadata {
-        eprintln!("Debugging executable with metadata: {:?}", *metadata);
+        eprintln!("Debugging executable with metadata ({})", metadata);
     }
 
     let connection: Box<dyn ConnectionExt<Error = std::io::Error>> =
@@ -671,13 +671,7 @@ impl<'a, 'b, C: ContextObject> MonitorCmd for Interpreter<'a, 'b, C> {
     ) -> Result<(), Self::Error> {
         match cmd {
             b"metadata" => match &self.vm.debug_metadata {
-                Some(metadata) => {
-                    if let Ok(metadata) = str::from_utf8(metadata) {
-                        outputln!(out, "{}", metadata);
-                    } else {
-                        out.write_raw(metadata.as_slice())
-                    }
-                }
+                Some(metadata) => outputln!(out, "{}", metadata),
                 None => outputln!(out, "no metadata present"),
             },
             _ => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -308,7 +308,7 @@ pub struct EbpfVm<'a, C: ContextObject> {
     pub debug_port: Option<u16>,
     /// Debug metadata passed
     #[cfg(feature = "debugger")]
-    pub debug_metadata: Option<Vec<u8>>,
+    pub debug_metadata: Option<String>,
 }
 
 impl<'a, C: ContextObject> EbpfVm<'a, C> {

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -86,6 +86,7 @@ fn test_gdbstub_architecture() {
     use std::time::Duration;
 
     const GDBSTUB_TEST_DEBUG_PORT: &'static str = "11212";
+    const METADATA: &'static str = "6CSmiViMaAguKgxNVwU8TWMPViQbtL5KKoFrDwWwtYNR";
 
     fn read_reply<R: BufRead>(reader: &mut R) -> std::io::Result<String> {
         let mut buf = Vec::new();
@@ -131,6 +132,7 @@ fn test_gdbstub_architecture() {
             );
             vm.context_object_pointer.remaining = 10_000_000_000;
             vm.debug_port = Some(debug_port);
+            vm.debug_metadata = Some(METADATA.into());
             vm.execute_program(&executable, true).1.unwrap();
         });
         // If this is set leave the stub port listening hence
@@ -165,6 +167,17 @@ fn test_gdbstub_architecture() {
                 writer.write_all(b"$pc#d3")?;
                 let reply = read_reply(&mut reader)?;
                 assert_eq!("+$00e40b540200*!#01", reply);
+
+                // Check the monitor command returns the expected metadata.
+                writer.write_all(b"$qRcmd,6d65746164617461#9d")?;
+                let reply = read_reply(&mut reader)?;
+                assert_eq!(
+                    "+$O3643536d6956694d614167754b67784e5677553854574d5056695162744c3\
+54b4b6f4672447757* 4594e520a#9e",
+                    reply
+                );
+                let reply = read_reply(&mut reader)?;
+                assert_eq!("$OK#9a", reply);
 
                 // Gracefully shutdown the remote gdbstub.
                 writer.write_all(b"$D#44")?;


### PR DESCRIPTION
### The problem

We need to know deterministically what we're going to debug.

### Solution

Pass debug metadata in the VM itself that can later be read from the debugger client using a custom monitor command.
For example this could be the interface through which the program_id is made visible to the debugger client.
Everything is still fully gated behind the debugger feature and the hot path isn't touched at all.
The debug_port is tweaked similarly.
By passing for example a string of the program_id the base58 conversion is already taken care of and there would be no need for additional processing later in the client.
I've extended the unittest to do a basic cover of this functionality.

Passing the metadata from the VM creator is as simple as:
```rust
        #[cfg(feature = "sbpf-debugger")]
        {
            vm.debug_port = debug_port;
            vm.debug_metadata = Some(program_id.to_string()); // The addition
        }
        vm.context_object_pointer.execute_time = Some(Measure::start("execute"));
        vm.registers[1] = ebpf::MM_INPUT_START;
```

Playing with this PR:
```text
DEBUG_GDBSTUB_ARCH=true cargo test --features debugger -- --nocapture --exact test_gdbstub_architecture
...
Debugging executable with metadata (6CSmiViMaAguKgxNVwU8TWMPViQbtL5KKoFrDwWwtYNR)
Waiting for a Debugger connection on "127.0.0.1:11212"...
Debugger connected from 127.0.0.1:57546
```

Then from `lldb`:
```text
~/.cache/solana/v1.53/platform-tools/llvm/bin/solana-lldb
(lldb) gdb-remote 127.0.0.1:11212
(lldb) process plugin packet monitor metadata
6CSmiViMaAguKgxNVwU8TWMPViQbtL5KKoFrDwWwtYNR
  packet: qRcmd,6d65746164617461
response: OK
(lldb)
```