### PR TITLE
feat: callx uses dst reg

### DIFF
--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -458,6 +458,8 @@ pub fn assemble<C: ContextObject>(
                             (CallReg, [Register(dst)]) => {
                                 if sbpf_version.callx_uses_src_reg() {
                                     insn(opc, 0, *dst, 0, 0)
+                                } else if sbpf_version.callx_uses_dst_reg() {
+                                    insn(opc, *dst, 0, 0, 0)
                                 } else {
                                     insn(opc, 0, 0, 0, *dst)
                                 }

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -299,7 +299,7 @@ pub fn disassemble_instruction<C: ContextObject>(
             }
             desc = format!("{} {}", name, function_name.unwrap_or_else(|| format!("{}", insn.imm)));
         },
-        ebpf::CALL_REG   => { name = "callx"; desc = format!("{} r{}", name, if sbpf_version.callx_uses_src_reg() { insn.src } else { insn.imm as u8 }); },
+        ebpf::CALL_REG   => { name = "callx"; desc = format!("{} r{}", name, if sbpf_version.callx_uses_src_reg() { insn.src } else if sbpf_version.callx_uses_dst_reg() { insn.dst } else { insn.imm as u8 }); },
         ebpf::EXIT       => { name = "exit"; desc = name.to_string(); },
 
         _                => { name = "unknown"; desc = format!("{} opcode={:#x}", name, insn.opc); },

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -528,6 +528,8 @@ impl<'a, 'b, C: ContextObject> Interpreter<'a, 'b, C> {
             ebpf::CALL_REG   => {
                 let target_pc = if self.executable.get_sbpf_version().callx_uses_src_reg() {
                     self.reg[src]
+                } else if self.executable.get_sbpf_version().callx_uses_dst_reg() {
+                    self.reg[dst]
                 } else {
                     self.reg[insn.imm as usize]
                 };

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -839,6 +839,8 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
                 ebpf::CALL_REG  => {
                     let target_pc = if self.executable.get_sbpf_version().callx_uses_src_reg() {
                         src
+                    } else if self.executable.get_sbpf_version().callx_uses_dst_reg() {
+                        dst
                     } else {
                         REGISTER_MAP[insn.imm as usize]
                     };

--- a/src/program.rs
+++ b/src/program.rs
@@ -85,6 +85,10 @@ impl SBPFVersion {
     pub fn enable_jmp32(self) -> bool {
         self >= SBPFVersion::V3
     }
+    /// ... SIMD-0377
+    pub fn callx_uses_dst_reg(self) -> bool {
+        self >= SBPFVersion::V3
+    }
 
     /// Calculate the target program counter for a CALL_IMM instruction depending on
     /// the SBPF version.

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -209,6 +209,8 @@ fn check_callx_register(
 ) -> Result<(), VerifierError> {
     let reg = if sbpf_version.callx_uses_src_reg() {
         insn.src as i64
+    } else if sbpf_version.callx_uses_dst_reg() {
+        insn.dst as i64
     } else {
         insn.imm
     };

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -141,7 +141,7 @@ fn test_jeq() {
 fn test_call_reg() {
     assert_eq!(
         asm("callx r3"),
-        Ok(vec![insn(0, ebpf::CALL_REG, 0, 0, 0, 3)])
+        Ok(vec![insn(0, ebpf::CALL_REG, 3, 0, 0, 0)])
     );
 }
 

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -387,3 +387,19 @@ fn test_large_immediate() {
     disasm!("entrypoint:\n    add64 r1, -1\n");
     disasm!("entrypoint:\n    add64 r1, -1\n");
 }
+
+#[test]
+fn test_callx() {
+    for version in [
+        SBPFVersion::V0,
+        SBPFVersion::V2,
+        SBPFVersion::V3,
+        SBPFVersion::V4,
+    ] {
+        let config = Config {
+            enabled_sbpf_versions: version..=version,
+            ..Config::default()
+        };
+        disasm!("entrypoint:\n    callx r8\n", config);
+    }
+}


### PR DESCRIPTION
As described in [SIMD-0377](https://github.com/solana-foundation/solana-improvement-documents/pull/377), starting with SBPF v3, use the `dst` register as the address to jump to for `callx`.