### PR TITLE
interpreter: inline ebpf instruction decoding 

### DIFF
--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -671,6 +671,7 @@ pub fn get_insn(prog: &[u8], pc: usize) -> Insn {
     get_insn_unchecked(prog, pc)
 }
 /// Same as `get_insn` except not checked
+#[inline]
 pub fn get_insn_unchecked(prog: &[u8], pc: usize) -> Insn {
     Insn {
         ptr: pc,


### PR DESCRIPTION
This is a relatively crude hammer that brings the delta between JIT and
interpreter from 17x to 12x (as measured on top of #100) in the
`bench_jit_vs_interpreter_empty_for_loop` benchmark. On every iteration
we'd spend significant time calling into this small helper function that
returns a non-trivial structure back, requiring significant setup, etc.

This change should also help JIT compilation speed quite a bit, but I
haven't checked this.

The logic flow here feels quite inefficient still, however, and this
specific part of the code still warrants further attention. In
particular, even after this change the machine code eagerly decodes the
entire isntruction into its parts rather than grabbing just the opcode
that it would need to pick the instruction to process. At that point
there might be *another* instruction word worth of arguments to decode…
It might (or might not!) be better to decode just the opcode and leave
it up to the compiler on how it wants to hoist decoding of the arguments
(if at all.)