### PR TITLE
mm: improve memory translation machine code quality / speed slightly

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -296,7 +296,7 @@ pub struct EbpfVm<'a, C: ContextObject> {
     /// ProgramResult inlined
     pub program_result: ProgramResult,
     /// MemoryMapping inlined
-    pub memory_mapping: MemoryMapping<'a>,
+    pub memory_mapping: MemoryMapping,
     /// Stack of CallFrames used by the Interpreter
     pub call_frames: Vec<CallFrame>,
     /// Loader built-in program
@@ -314,7 +314,7 @@ impl<'a, C: ContextObject> EbpfVm<'a, C> {
         loader: Arc<BuiltinProgram<C>>,
         sbpf_version: SBPFVersion,
         context_object: &'a mut C,
-        mut memory_mapping: MemoryMapping<'a>,
+        mut memory_mapping: MemoryMapping,
         stack_len: usize,
     ) -> Self {
         let config = loader.get_config();

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -207,7 +207,7 @@ pub fn create_memory_mapping<'a, C: ContextObject>(
     heap: &'a mut AlignedMemory<{ HOST_ALIGN }>,
     additional_regions: Vec<MemoryRegion>,
     access_violation_handler: Option<AccessViolationHandler>,
-) -> Result<MemoryMapping<'a>, EbpfError> {
+) -> Result<MemoryMapping, EbpfError> {
     let config = executable.get_config();
     let sbpf_version = executable.get_sbpf_version();
     let regions: Vec<MemoryRegion> = vec![


### PR DESCRIPTION
This is best reviewed commit-by-commit. The first two commits are a pure win. 3rd commit was an experiment that unfortunately ended up with mixed results but an naively still an overall. I'm not quite sure which of the cargo benchmarks are the most important, though. Happy to back that 3rd commit out altogether if it turns out that its a regression on a real-world scenario (any suggestions on what to test?)

All three commits are Not a Functional Change.

Overall if I just sum up the `cargo bench` nanos and compare before/after the 1st commit is a -6% runtime; 2nd commit is another -3.5%; The broken-down numbers are available in each commit message.