### PR TITLE
jit: have compiler determine EbpfVm offsets

### DIFF
--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -124,7 +124,7 @@ impl Default for CfgNode {
     }
 }
 
-struct DummyContextObject {}
+pub(crate) struct DummyContextObject {}
 
 impl ContextObject for DummyContextObject {
     fn consume(&mut self, _amount: u64) {}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -19,9 +19,9 @@ use crate::{
     interpreter::Interpreter,
     memory_region::MemoryMapping,
     program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
-    static_analysis::{Analysis, RegisterTraceEntry},
+    static_analysis::{Analysis, DummyContextObject, RegisterTraceEntry},
 };
-use std::{collections::BTreeMap, fmt::Debug};
+use std::{collections::BTreeMap, fmt::Debug, mem::offset_of};
 
 #[cfg(feature = "shuttle-test")]
 use shuttle::sync::Arc;
@@ -195,27 +195,28 @@ pub struct CallFrame {
 /// Indices of slots inside [EbpfVm]
 pub enum RuntimeEnvironmentSlot {
     /// [EbpfVm::host_stack_pointer]
-    HostStackPointer = 0,
+    HostStackPointer = offset_of!(EbpfVm<DummyContextObject>, host_stack_pointer) as isize,
     /// [EbpfVm::call_depth]
-    CallDepth = 1,
+    CallDepth = offset_of!(EbpfVm<DummyContextObject>, call_depth) as isize,
     /// [EbpfVm::context_object_pointer]
-    ContextObjectPointer = 2,
+    ContextObjectPointer = offset_of!(EbpfVm<DummyContextObject>, context_object_pointer) as isize,
     /// [EbpfVm::previous_instruction_meter]
-    PreviousInstructionMeter = 3,
+    PreviousInstructionMeter =
+        offset_of!(EbpfVm<DummyContextObject>, previous_instruction_meter) as isize,
     /// [EbpfVm::due_insn_count]
-    DueInsnCount = 4,
+    DueInsnCount = offset_of!(EbpfVm<DummyContextObject>, due_insn_count) as isize,
     /// [EbpfVm::stopwatch_numerator]
-    StopwatchNumerator = 5,
+    StopwatchNumerator = offset_of!(EbpfVm<DummyContextObject>, stopwatch_numerator) as isize,
     /// [EbpfVm::stopwatch_denominator]
-    StopwatchDenominator = 6,
+    StopwatchDenominator = offset_of!(EbpfVm<DummyContextObject>, stopwatch_denominator) as isize,
     /// [EbpfVm::registers]
-    Registers = 7,
+    Registers = offset_of!(EbpfVm<DummyContextObject>, registers) as isize,
     /// [EbpfVm::program_result]
-    ProgramResult = 19,
+    ProgramResult = offset_of!(EbpfVm<DummyContextObject>, program_result) as isize,
     /// [EbpfVm::memory_mapping]
-    MemoryMapping = 27,
+    MemoryMapping = offset_of!(EbpfVm<DummyContextObject>, memory_mapping) as isize,
     /// [EbpfVm::register_trace]
-    RegisterTrace = 54,
+    RegisterTrace = offset_of!(EbpfVm<DummyContextObject>, register_trace) as isize,
 }
 
 /// A virtual machine to run eBPF programs.

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -32,8 +32,8 @@ fn test_runtime_environment_slots() {
             assert_eq!(
                 unsafe {
                     std::ptr::addr_of!($env.$entry)
-                        .cast::<u64>()
-                        .offset_from(std::ptr::addr_of!($env).cast::<u64>()) as usize
+                        .cast::<u8>()
+                        .offset_from(std::ptr::addr_of!($env).cast::<u8>()) as usize
                 },
                 RuntimeEnvironmentSlot::$slot as usize,
             );


### PR DESCRIPTION
This, unlike manually specified offsets, can never go wrong (unless somebody uses code compiled for wrong data structures.)

I hit this going wrong after changing `MemoryMapping`.