### PR TITLE
style: consolidate multiple use blocks into single

### DIFF
--- a/benches/elf_loader.rs
+++ b/benches/elf_loader.rs
@@ -10,10 +10,12 @@ extern crate solana_sbpf;
 extern crate test;
 extern crate test_utils;
 
-use solana_sbpf::{elf::Executable, program::BuiltinProgram, vm::Config};
-use std::{fs::File, io::Read, sync::Arc};
-use test::Bencher;
-use test_utils::{syscalls, TestContextObject};
+use {
+    solana_sbpf::{elf::Executable, program::BuiltinProgram, vm::Config},
+    std::{fs::File, io::Read, sync::Arc},
+    test::Bencher,
+    test_utils::{syscalls, TestContextObject},
+};
 
 fn loader() -> Arc<BuiltinProgram<TestContextObject>> {
     let mut loader = BuiltinProgram::new_loader(Config::default());

--- a/benches/jit_compile.rs
+++ b/benches/jit_compile.rs
@@ -9,10 +9,12 @@
 extern crate solana_sbpf;
 extern crate test;
 
-use solana_sbpf::{elf::Executable, program::BuiltinProgram, verifier::RequisiteVerifier};
-use std::{fs::File, io::Read, sync::Arc};
-use test::Bencher;
-use test_utils::{create_vm, TestContextObject};
+use {
+    solana_sbpf::{elf::Executable, program::BuiltinProgram, verifier::RequisiteVerifier},
+    std::{fs::File, io::Read, sync::Arc},
+    test::Bencher,
+    test_utils::{create_vm, TestContextObject},
+};
 
 #[bench]
 fn bench_init_vm(bencher: &mut Bencher) {

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -10,13 +10,15 @@ extern crate rand;
 extern crate solana_sbpf;
 extern crate test;
 
-use rand::{rngs::SmallRng, Rng, SeedableRng};
-use solana_sbpf::{
-    memory_region::{AccessType, MemoryMapping, MemoryRegion},
-    program::SBPFVersion,
-    vm::Config,
+use {
+    rand::{rngs::SmallRng, Rng, SeedableRng},
+    solana_sbpf::{
+        memory_region::{AccessType, MemoryMapping, MemoryRegion},
+        program::SBPFVersion,
+        vm::Config,
+    },
+    test::Bencher,
 };
-use test::Bencher;
 
 fn generate_memory_regions(
     entries: usize,

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -11,10 +11,12 @@ extern crate test;
 
 #[cfg(all(feature = "jit", not(target_os = "windows"), target_arch = "x86_64"))]
 use solana_sbpf::{ebpf, memory_region::MemoryRegion, program::SBPFVersion, vm::Config};
-use solana_sbpf::{elf::Executable, program::BuiltinProgram, verifier::RequisiteVerifier};
-use std::{fs::File, io::Read, sync::Arc};
-use test::Bencher;
-use test_utils::{create_vm, TestContextObject};
+use {
+    solana_sbpf::{elf::Executable, program::BuiltinProgram, verifier::RequisiteVerifier},
+    std::{fs::File, io::Read, sync::Arc},
+    test::Bencher,
+    test_utils::{create_vm, TestContextObject},
+};
 
 #[bench]
 fn bench_init_interpreter_start(bencher: &mut Bencher) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,17 +1,19 @@
-use clap::{crate_version, App, Arg};
-use solana_sbpf::{
-    aligned_memory::AlignedMemory,
-    assembler::assemble,
-    ebpf,
-    elf::Executable,
-    memory_region::{MemoryMapping, MemoryRegion},
-    program::BuiltinProgram,
-    static_analysis::Analysis,
-    verifier::RequisiteVerifier,
-    vm::{Config, DynamicAnalysis, EbpfVm},
+use {
+    clap::{crate_version, App, Arg},
+    solana_sbpf::{
+        aligned_memory::AlignedMemory,
+        assembler::assemble,
+        ebpf,
+        elf::Executable,
+        memory_region::{MemoryMapping, MemoryRegion},
+        program::BuiltinProgram,
+        static_analysis::Analysis,
+        verifier::RequisiteVerifier,
+        vm::{Config, DynamicAnalysis, EbpfVm},
+    },
+    std::{fs::File, io::Read, path::Path, sync::Arc},
+    test_utils::TestContextObject,
 };
-use std::{fs::File, io::Read, path::Path, sync::Arc};
-use test_utils::TestContextObject;
 
 fn main() {
     let matches = App::new("Solana BPF CLI")

--- a/examples/disassemble.rs
+++ b/examples/disassemble.rs
@@ -5,13 +5,16 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate solana_sbpf;
-use solana_sbpf::{
-    elf::Executable,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
-    static_analysis::Analysis,
+
+use {
+    solana_sbpf::{
+        elf::Executable,
+        program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+        static_analysis::Analysis,
+    },
+    std::sync::Arc,
+    test_utils::TestContextObject,
 };
-use std::sync::Arc;
-use test_utils::TestContextObject;
 
 // Simply disassemble a program into human-readable instructions.
 fn main() {

--- a/examples/to_json.rs
+++ b/examples/to_json.rs
@@ -6,18 +6,20 @@
 
 #[macro_use]
 extern crate json;
-
 extern crate elf;
-use std::path::PathBuf;
-
 extern crate solana_sbpf;
-use solana_sbpf::{
-    elf::Executable,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
-    static_analysis::Analysis,
+
+use {
+    solana_sbpf::{
+        elf::Executable,
+        program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+        static_analysis::Analysis,
+    },
+    std::path::PathBuf,
+    std::sync::Arc,
+    test_utils::TestContextObject,
 };
-use std::sync::Arc;
-use test_utils::TestContextObject;
+
 // Turn a program into a JSON string.
 //
 // Relies on `json` crate.

--- a/fuzz/fuzz_targets/common.rs
+++ b/fuzz/fuzz_targets/common.rs
@@ -1,8 +1,8 @@
-use std::mem::size_of;
-
-use arbitrary::{Arbitrary, Unstructured};
-
-use solana_sbpf::{program::SBPFVersion, vm::Config};
+use {
+    arbitrary::{Arbitrary, Unstructured},
+    solana_sbpf::{program::SBPFVersion, vm::Config},
+    std::mem::size_of,
+};
 
 #[derive(Debug)]
 pub struct ConfigTemplate {

--- a/fuzz/fuzz_targets/dumb.rs
+++ b/fuzz/fuzz_targets/dumb.rs
@@ -1,19 +1,18 @@
 #![no_main]
 
-use std::hint::black_box;
-
-use libfuzzer_sys::fuzz_target;
-
-use solana_sbpf::{
-    ebpf,
-    elf::Executable,
-    memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
-    verifier::{RequisiteVerifier, Verifier},
+use {
+    crate::common::ConfigTemplate,
+    libfuzzer_sys::fuzz_target,
+    solana_sbpf::{
+        ebpf,
+        elf::Executable,
+        memory_region::MemoryRegion,
+        program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
+        verifier::{RequisiteVerifier, Verifier},
+    },
+    std::hint::black_box,
+    test_utils::{create_vm, TestContextObject},
 };
-use test_utils::{create_vm, TestContextObject};
-
-use crate::common::ConfigTemplate;
 
 mod common;
 

--- a/fuzz/fuzz_targets/semantic_aware.rs
+++ b/fuzz/fuzz_targets/semantic_aware.rs
@@ -1,9 +1,10 @@
 #![allow(dead_code)]
 // based on: https://sourceware.org/binutils/docs/as/BPF-Opcodes.html
 
-use std::num::NonZeroI32;
-
-use solana_sbpf::insn_builder::{Arch, BpfCode, Cond, Endian, Instruction, MemSize, Move, Source};
+use {
+    solana_sbpf::insn_builder::{Arch, BpfCode, Cond, Endian, Instruction, MemSize, Move, Source},
+    std::num::NonZeroI32,
+};
 
 #[derive(arbitrary::Arbitrary, Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Register(u8);

--- a/fuzz/fuzz_targets/smart.rs
+++ b/fuzz/fuzz_targets/smart.rs
@@ -1,21 +1,20 @@
 #![no_main]
 
-use std::hint::black_box;
-
-use libfuzzer_sys::fuzz_target;
-
-use grammar_aware::*;
-use solana_sbpf::{
-    ebpf,
-    elf::Executable,
-    insn_builder::{Arch, IntoBytes},
-    memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
-    verifier::{RequisiteVerifier, Verifier},
+use {
+    crate::common::ConfigTemplate,
+    grammar_aware::*,
+    libfuzzer_sys::fuzz_target,
+    solana_sbpf::{
+        ebpf,
+        elf::Executable,
+        insn_builder::{Arch, IntoBytes},
+        memory_region::MemoryRegion,
+        program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
+        verifier::{RequisiteVerifier, Verifier},
+    },
+    std::hint::black_box,
+    test_utils::{create_vm, TestContextObject},
 };
-use test_utils::{create_vm, TestContextObject};
-
-use crate::common::ConfigTemplate;
 
 mod common;
 mod grammar_aware;

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -1,19 +1,19 @@
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
-
-use grammar_aware::*;
-use solana_sbpf::{
-    ebpf,
-    elf::Executable,
-    insn_builder::{Arch, Instruction, IntoBytes},
-    memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
-    verifier::{RequisiteVerifier, Verifier},
+use {
+    crate::common::ConfigTemplate,
+    grammar_aware::*,
+    libfuzzer_sys::fuzz_target,
+    solana_sbpf::{
+        ebpf,
+        elf::Executable,
+        insn_builder::{Arch, Instruction, IntoBytes},
+        memory_region::MemoryRegion,
+        program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
+        verifier::{RequisiteVerifier, Verifier},
+    },
+    test_utils::{create_vm, TestContextObject},
 };
-use test_utils::{create_vm, TestContextObject};
-
-use crate::common::ConfigTemplate;
 
 mod common;
 mod grammar_aware;

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -1,19 +1,19 @@
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
-
-use semantic_aware::*;
-use solana_sbpf::{
-    ebpf,
-    elf::Executable,
-    insn_builder::IntoBytes,
-    memory_region::MemoryRegion,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
-    verifier::{RequisiteVerifier, Verifier},
+use {
+    crate::common::ConfigTemplate,
+    libfuzzer_sys::fuzz_target,
+    semantic_aware::*,
+    solana_sbpf::{
+        ebpf,
+        elf::Executable,
+        insn_builder::IntoBytes,
+        memory_region::MemoryRegion,
+        program::{BuiltinFunction, BuiltinProgram, FunctionRegistry},
+        verifier::{RequisiteVerifier, Verifier},
+    },
+    test_utils::{create_vm, TestContextObject},
 };
-use test_utils::{create_vm, TestContextObject};
-
-use crate::common::ConfigTemplate;
 
 mod common;
 mod semantic_aware;

--- a/fuzz/fuzz_targets/verify_semantic_aware.rs
+++ b/fuzz/fuzz_targets/verify_semantic_aware.rs
@@ -1,16 +1,16 @@
 #![no_main]
 
-use libfuzzer_sys::fuzz_target;
-
-use semantic_aware::*;
-use solana_sbpf::{
-    insn_builder::IntoBytes,
-    program::{BuiltinFunction, FunctionRegistry},
-    verifier::{RequisiteVerifier, Verifier},
+use {
+    crate::common::ConfigTemplate,
+    libfuzzer_sys::fuzz_target,
+    semantic_aware::*,
+    solana_sbpf::{
+        insn_builder::IntoBytes,
+        program::{BuiltinFunction, FunctionRegistry},
+        verifier::{RequisiteVerifier, Verifier},
+    },
+    test_utils::TestContextObject,
 };
-use test_utils::TestContextObject;
-
-use crate::common::ConfigTemplate;
 
 mod common;
 mod semantic_aware;

--- a/src/assembler.rs
+++ b/src/assembler.rs
@@ -7,22 +7,24 @@
 
 //! This module translates eBPF assembly language to binary.
 
-use self::InstructionType::{
-    AluBinary, AluUnary, CallImm, CallReg, Endian, JumpConditional, JumpUnconditional, LoadDwImm,
-    LoadReg, NoOperand, StoreImm, StoreReg, Syscall,
-};
-use crate::{
-    asm_parser::{
-        parse,
-        Operand::{Integer, Label, Memory, Register},
-        Statement,
+use {
+    self::InstructionType::{
+        AluBinary, AluUnary, CallImm, CallReg, Endian, JumpConditional, JumpUnconditional,
+        LoadDwImm, LoadReg, NoOperand, StoreImm, StoreReg, Syscall,
     },
-    ebpf::{self, Insn},
-    elf::Executable,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
-    vm::ContextObject,
+    crate::{
+        asm_parser::{
+            parse,
+            Operand::{Integer, Label, Memory, Register},
+            Statement,
+        },
+        ebpf::{self, Insn},
+        elf::Executable,
+        program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+        vm::ContextObject,
+    },
+    std::collections::HashMap,
 };
-use std::collections::HashMap;
 
 #[cfg(not(feature = "shuttle-test"))]
 use std::sync::Arc;

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,33 +1,32 @@
 //! Debugger for the virtual machines' interpreter.
 
-use std::net::{TcpListener, TcpStream};
-
-use gdbstub::common::Signal;
-use gdbstub::conn::ConnectionExt;
-use gdbstub::stub::{state_machine, GdbStub, SingleThreadStopReason};
-
-use gdbstub::arch::lldb::{Encoding, Format, Generic, Register};
-use gdbstub::arch::RegId;
-
-use gdbstub::target;
-use gdbstub::target::{Target, TargetError, TargetResult};
-
-use core::convert::TryInto;
-
-use bpf_arch::reg::id::BpfRegId;
-use bpf_arch::reg::BpfRegs;
-use bpf_arch::Bpf;
-use gdbstub::target::ext::base::singlethread::{SingleThreadBase, SingleThreadResume};
-use gdbstub::target::ext::lldb_register_info_override::{Callback, CallbackToken};
-use gdbstub::target::ext::section_offsets::Offsets;
-
-use crate::program::SBPFVersion;
-use crate::{
-    ebpf,
-    error::{EbpfError, ProgramResult},
-    interpreter::{DebugState, Interpreter},
-    memory_region::AccessType,
-    vm::ContextObject,
+use {
+    crate::{
+        ebpf,
+        error::{EbpfError, ProgramResult},
+        interpreter::{DebugState, Interpreter},
+        memory_region::AccessType,
+        program::SBPFVersion,
+        vm::ContextObject,
+    },
+    bpf_arch::{id::BpfRegId, reg::BpfRegs, Bpf},
+    core::convert::TryInto,
+    gdbstub::{
+        arch::{
+            lldb::{Encoding, Format, Generic, Register},
+            RegId,
+        },
+        common::Signal,
+        conn::ConnectionExt,
+        stub::{state_machine, GdbStub, SingleThreadStopReason},
+        target::ext::{
+            base::singlethread::{SingleThreadBase, SingleThreadResume},
+            lldb_register_info_override::{Callback, CallbackToken},
+            section_offsets::Offsets,
+        },
+        target::{self, Target, TargetError, TargetResult},
+    },
+    std::net::{TcpListener, TcpStream},
 };
 
 type DynResult<T> = Result<T, Box<dyn std::error::Error>>;

--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -8,13 +8,15 @@
 //! Functions in this module are used to handle eBPF programs with a higher level representation,
 //! for example to disassemble the code into a human-readable format.
 
-use crate::{
-    ebpf,
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
-    static_analysis::CfgNode,
-    vm::ContextObject,
+use {
+    crate::{
+        ebpf,
+        program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+        static_analysis::CfgNode,
+        vm::ContextObject,
+    },
+    std::collections::BTreeMap,
 };
-use std::collections::BTreeMap;
 
 fn resolve_label(cfg_nodes: &BTreeMap<usize, CfgNode>, pc: usize) -> &str {
     cfg_nodes

--- a/src/ebpf.rs
+++ b/src/ebpf.rs
@@ -18,9 +18,11 @@
 //! <https://www.kernel.org/doc/Documentation/networking/filter.txt>, or for a shorter version of
 //! the list of the operation codes: <https://github.com/iovisor/bpf-docs/blob/master/eBPF.md>
 
-use byteorder::{ByteOrder, LittleEndian};
-use hash32::{Hasher, Murmur3Hasher};
-use std::{fmt, hash::Hash};
+use {
+    byteorder::{ByteOrder, LittleEndian},
+    hash32::{Hasher, Murmur3Hasher},
+    std::{fmt, hash::Hash},
+};
 
 /// Maximum number of instructions in an eBPF program.
 pub const PROG_MAX_INSNS: usize = 65_536;

--- a/src/elf_parser/mod.rs
+++ b/src/elf_parser/mod.rs
@@ -3,10 +3,11 @@
 pub mod consts;
 pub mod types;
 
-use std::{fmt, mem, ops::Range, slice};
-
-use crate::{ArithmeticOverflow, ErrCheckedArithmetic};
-use {consts::*, types::*};
+use {
+    crate::{ArithmeticOverflow, ErrCheckedArithmetic},
+    std::{fmt, mem, ops::Range, slice},
+    {consts::*, types::*},
+};
 
 /// Maximum length of section name allowed.
 pub const SECTION_NAME_LENGTH_MAXIMUM: usize = 16;

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -18,27 +18,28 @@ use rand::{thread_rng, Rng};
 #[cfg(feature = "shuttle-test")]
 use shuttle::rand::{thread_rng, Rng};
 
-use rand::{
-    distributions::{Distribution, Uniform},
-    rngs::SmallRng,
-    SeedableRng,
-};
-use std::{fmt::Debug, mem, ptr};
-
-use crate::{
-    ebpf::{self, FIRST_SCRATCH_REG, FRAME_PTR_REG, INSN_SIZE, SCRATCH_REGS},
-    elf::Executable,
-    error::{EbpfError, ProgramResult},
-    memory_management::{
-        allocate_pages, free_pages, get_system_page_size, protect_pages, round_to_page_size,
+use {
+    crate::{
+        ebpf::{self, FIRST_SCRATCH_REG, FRAME_PTR_REG, INSN_SIZE, SCRATCH_REGS},
+        elf::Executable,
+        error::{EbpfError, ProgramResult},
+        memory_management::{
+            allocate_pages, free_pages, get_system_page_size, protect_pages, round_to_page_size,
+        },
+        memory_region::MemoryMapping,
+        rand::{
+            distributions::{Distribution, Uniform},
+            rngs::SmallRng,
+            SeedableRng,
+        },
+        vm::{get_runtime_environment_key, Config, ContextObject, EbpfVm, RuntimeEnvironmentSlot},
+        x86::{
+            FenceType, X86IndirectAccess, X86Instruction,
+            X86Register::{self, *},
+            ARGUMENT_REGISTERS, CALLEE_SAVED_REGISTERS, CALLER_SAVED_REGISTERS,
+        },
     },
-    memory_region::MemoryMapping,
-    vm::{get_runtime_environment_key, Config, ContextObject, EbpfVm, RuntimeEnvironmentSlot},
-    x86::{
-        FenceType, X86IndirectAccess, X86Instruction,
-        X86Register::{self, *},
-        ARGUMENT_REGISTERS, CALLEE_SAVED_REGISTERS, CALLER_SAVED_REGISTERS,
-    },
+    std::{fmt::Debug, mem, ptr},
 };
 
 /// The maximum machine code length in bytes of a program with no guest instructions

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -1,13 +1,15 @@
 //! This module defines memory regions
 
-use crate::{
-    aligned_memory::Pod,
-    ebpf,
-    error::{EbpfError, ProgramResult},
-    program::SBPFVersion,
-    vm::Config,
+use {
+    crate::{
+        aligned_memory::Pod,
+        ebpf,
+        error::{EbpfError, ProgramResult},
+        program::SBPFVersion,
+        vm::Config,
+    },
+    std::{array, cell::UnsafeCell, fmt, mem, ops::Range, ptr},
 };
-use std::{array, cell::UnsafeCell, fmt, mem, ops::Range, ptr};
 
 /* Explanation of the Gapped Memory
 

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -1,16 +1,18 @@
 #![allow(clippy::arithmetic_side_effects)]
 //! Static Byte Code Analysis
 
-use crate::disassembler::disassemble_instruction;
-use crate::{
-    ebpf,
-    elf::Executable,
-    error::EbpfError,
-    program::SBPFVersion,
-    vm::{ContextObject, DynamicAnalysis},
+use {
+    crate::{
+        disassembler::disassemble_instruction,
+        ebpf,
+        elf::Executable,
+        error::EbpfError,
+        program::SBPFVersion,
+        vm::{ContextObject, DynamicAnalysis},
+    },
+    rustc_demangle::demangle,
+    std::collections::{BTreeMap, BTreeSet, HashMap, HashSet},
 };
-use rustc_demangle::demangle;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 /// Register state recorded after executing one instruction
 ///

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -12,12 +12,14 @@
 
 //! Verifies that the bytecode is valid for the given config.
 
-use crate::{
-    ebpf,
-    program::{BuiltinFunction, FunctionRegistry, SBPFVersion},
-    vm::{Config, ContextObject},
+use {
+    crate::{
+        ebpf,
+        program::{BuiltinFunction, FunctionRegistry, SBPFVersion},
+        vm::{Config, ContextObject},
+    },
+    thiserror::Error,
 };
-use thiserror::Error;
 
 /// Error definitions
 #[derive(Debug, Error, Eq, PartialEq)]

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -12,16 +12,18 @@
 
 //! Virtual machine for eBPF programs.
 
-use crate::{
-    ebpf,
-    elf::Executable,
-    error::{EbpfError, ProgramResult},
-    interpreter::Interpreter,
-    memory_region::MemoryMapping,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
-    static_analysis::{Analysis, DummyContextObject, RegisterTraceEntry},
+use {
+    crate::{
+        ebpf,
+        elf::Executable,
+        error::{EbpfError, ProgramResult},
+        interpreter::Interpreter,
+        memory_region::MemoryMapping,
+        program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+        static_analysis::{Analysis, DummyContextObject, RegisterTraceEntry},
+    },
+    std::{collections::BTreeMap, fmt::Debug, mem::offset_of},
 };
-use std::{collections::BTreeMap, fmt::Debug, mem::offset_of};
 
 #[cfg(feature = "shuttle-test")]
 use shuttle::sync::Arc;

--- a/test_utils/src/syscalls.rs
+++ b/test_utils/src/syscalls.rs
@@ -21,13 +21,15 @@
 //! value. Hence some syscalls have unused arguments, or return a 0 value in all cases, in order to
 //! respect this convention.
 
-use crate::TestContextObject;
-use solana_sbpf::{
-    declare_builtin_function,
-    error::EbpfError,
-    memory_region::{AccessType, MemoryMapping},
+use {
+    crate::TestContextObject,
+    solana_sbpf::{
+        declare_builtin_function,
+        error::EbpfError,
+        memory_region::{AccessType, MemoryMapping},
+    },
+    std::{slice::from_raw_parts, str::from_utf8},
 };
-use std::{slice::from_raw_parts, str::from_utf8};
 
 declare_builtin_function!(
     /// Prints its **last three** arguments to standard output. The **first two** arguments are

--- a/tests/assembler.rs
+++ b/tests/assembler.rs
@@ -10,11 +10,13 @@
 extern crate solana_sbpf;
 extern crate test_utils;
 
-use solana_sbpf::program::SBPFVersion;
-use solana_sbpf::vm::Config;
-use solana_sbpf::{assembler::assemble, ebpf, program::BuiltinProgram};
-use std::sync::Arc;
-use test_utils::{TestContextObject, TCP_SACK_ASM, TCP_SACK_BIN};
+use {
+    solana_sbpf::{
+        assembler::assemble, ebpf, program::BuiltinProgram, program::SBPFVersion, vm::Config,
+    },
+    std::sync::Arc,
+    test_utils::{TestContextObject, TCP_SACK_ASM, TCP_SACK_BIN},
+};
 
 fn asm(src: &str) -> Result<Vec<ebpf::Insn>, String> {
     asm_with_config(src, Config::default())

--- a/tests/disassembler.rs
+++ b/tests/disassembler.rs
@@ -9,12 +9,17 @@
 // copied, modified, or distributed except according to those terms.
 
 extern crate solana_sbpf;
-use solana_sbpf::program::SBPFVersion;
-use solana_sbpf::{
-    assembler::assemble, program::BuiltinProgram, static_analysis::Analysis, vm::Config,
+
+use {
+    solana_sbpf::{
+        assembler::assemble,
+        program::{BuiltinProgram, SBPFVersion},
+        static_analysis::Analysis,
+        vm::Config,
+    },
+    std::sync::Arc,
+    test_utils::TestContextObject,
 };
-use std::sync::Arc;
-use test_utils::TestContextObject;
 
 // Using a macro to keep actual line numbers in failure output
 macro_rules! disasm {

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -1,20 +1,24 @@
 #![allow(clippy::literal_string_with_formatting_args)]
 
-use byteorder::{ByteOrder, LittleEndian};
-use solana_sbpf::{
-    ebpf,
-    elf::{get_ro_region, ElfError, Executable, Section},
-    elf_parser::{
-        consts::{ELFCLASS32, ELFCLASS64, ELFDATA2LSB, ELFDATA2MSB, ELFOSABI_NONE, EM_BPF, ET_REL},
-        types::{Elf64Ehdr, Elf64Phdr, Elf64Shdr},
-        Elf64, ElfParserError, SECTION_NAME_LENGTH_MAXIMUM,
+use {
+    byteorder::{ByteOrder, LittleEndian},
+    solana_sbpf::{
+        ebpf,
+        elf::{get_ro_region, ElfError, Executable, Section},
+        elf_parser::{
+            consts::{
+                ELFCLASS32, ELFCLASS64, ELFDATA2LSB, ELFDATA2MSB, ELFOSABI_NONE, EM_BPF, ET_REL,
+            },
+            types::{Elf64Ehdr, Elf64Phdr, Elf64Shdr},
+            Elf64, ElfParserError, SECTION_NAME_LENGTH_MAXIMUM,
+        },
+        memory_region::{AccessType, MemoryMapping},
+        program::{BuiltinProgram, SBPFVersion},
+        vm::Config,
     },
-    memory_region::{AccessType, MemoryMapping},
-    program::{BuiltinProgram, SBPFVersion},
-    vm::Config,
+    std::{fs::File, io::Read, sync::Arc},
+    test_utils::{assert_error, syscalls, TestContextObject},
 };
-use std::{fs::File, io::Read, sync::Arc};
-use test_utils::{assert_error, syscalls, TestContextObject};
 
 type ElfExecutable = Executable<TestContextObject>;
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -14,25 +14,27 @@ extern crate solana_sbpf;
 extern crate test_utils;
 extern crate thiserror;
 
-use byteorder::{ByteOrder, LittleEndian};
 #[cfg(all(not(windows), target_arch = "x86_64"))]
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
-use solana_sbpf::{
-    assembler::assemble,
-    declare_builtin_function, ebpf,
-    elf::Executable,
-    error::{EbpfError, ProgramResult},
-    memory_region::{AccessType, MemoryMapping, MemoryRegion},
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
-    static_analysis::Analysis,
-    verifier::RequisiteVerifier,
-    vm::{Config, ContextObject},
-};
-use std::{fs::File, io::Read, sync::Arc};
-use test_utils::{
-    assert_error, compare_register_trace, create_vm, syscalls, test_interpreter_and_jit,
-    test_interpreter_and_jit_asm, test_interpreter_and_jit_elf, test_syscall_asm,
-    TestContextObject, PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH,
+use {
+    byteorder::{ByteOrder, LittleEndian},
+    solana_sbpf::{
+        assembler::assemble,
+        declare_builtin_function, ebpf,
+        elf::Executable,
+        error::{EbpfError, ProgramResult},
+        memory_region::{AccessType, MemoryMapping, MemoryRegion},
+        program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+        static_analysis::Analysis,
+        verifier::RequisiteVerifier,
+        vm::{Config, ContextObject},
+    },
+    std::{fs::File, io::Read, sync::Arc},
+    test_utils::{
+        assert_error, compare_register_trace, create_vm, syscalls, test_interpreter_and_jit,
+        test_interpreter_and_jit_asm, test_interpreter_and_jit_elf, test_syscall_asm,
+        TestContextObject, PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH,
+    },
 };
 
 // BPF_ALU32_LOAD : Arithmetic and Logic

--- a/tests/exercise_instructions.rs
+++ b/tests/exercise_instructions.rs
@@ -14,18 +14,20 @@ extern crate solana_sbpf;
 extern crate test_utils;
 extern crate thiserror;
 
-use rand::{rngs::SmallRng, RngCore, SeedableRng};
-use solana_sbpf::{
-    assembler::assemble,
-    ebpf,
-    memory_region::MemoryRegion,
-    program::{BuiltinProgram, SBPFVersion},
-    static_analysis::Analysis,
-    verifier::RequisiteVerifier,
-    vm::{Config, ContextObject},
+use {
+    rand::{rngs::SmallRng, RngCore, SeedableRng},
+    solana_sbpf::{
+        assembler::assemble,
+        ebpf,
+        memory_region::MemoryRegion,
+        program::{BuiltinProgram, SBPFVersion},
+        static_analysis::Analysis,
+        verifier::RequisiteVerifier,
+        vm::{Config, ContextObject},
+    },
+    std::sync::Arc,
+    test_utils::{compare_register_trace, create_vm, test_interpreter_and_jit, TestContextObject},
 };
-use std::sync::Arc;
-use test_utils::{compare_register_trace, create_vm, test_interpreter_and_jit, TestContextObject};
 
 // BPF_ALU32_LOAD : Arithmetic and Logic
 #[test]

--- a/tests/jit.rs
+++ b/tests/jit.rs
@@ -1,22 +1,24 @@
 #![allow(clippy::literal_string_with_formatting_args)]
 #![cfg(all(test, target_arch = "x86_64", not(target_os = "windows")))]
 
-use byteorder::{ByteOrder, LittleEndian};
-use solana_sbpf::{
-    disassembler::disassemble_instruction,
-    ebpf,
-    elf::Executable,
-    error::EbpfError,
-    jit::{
-        MACHINE_CODE_PER_INSTRUCTION_METER_CHECKPOINT, MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH,
-        MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION,
+use {
+    byteorder::{ByteOrder, LittleEndian},
+    solana_sbpf::{
+        disassembler::disassemble_instruction,
+        ebpf,
+        elf::Executable,
+        error::EbpfError,
+        jit::{
+            MACHINE_CODE_PER_INSTRUCTION_METER_CHECKPOINT, MAX_EMPTY_PROGRAM_MACHINE_CODE_LENGTH,
+            MAX_MACHINE_CODE_LENGTH_PER_INSTRUCTION,
+        },
+        program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
+        static_analysis::CfgNode,
+        vm::Config,
     },
-    program::{BuiltinProgram, FunctionRegistry, SBPFVersion},
-    static_analysis::CfgNode,
-    vm::Config,
+    std::{collections::BTreeMap, sync::Arc},
+    test_utils::{syscalls, TestContextObject},
 };
-use std::{collections::BTreeMap, sync::Arc};
-use test_utils::{syscalls, TestContextObject};
 
 fn create_mockup_executable(config: Config, program: &[u8]) -> Executable<TestContextObject> {
     let sbpf_version = *config.enabled_sbpf_versions.end();

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -24,17 +24,19 @@
 extern crate solana_sbpf;
 extern crate thiserror;
 
-use solana_sbpf::{
-    assembler::assemble,
-    ebpf,
-    elf::Executable,
-    program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
-    verifier::{RequisiteVerifier, Verifier, VerifierError},
-    vm::{Config, ContextObject},
+use {
+    solana_sbpf::{
+        assembler::assemble,
+        ebpf,
+        elf::Executable,
+        program::{BuiltinFunction, BuiltinProgram, FunctionRegistry, SBPFVersion},
+        verifier::{RequisiteVerifier, Verifier, VerifierError},
+        vm::{Config, ContextObject},
+    },
+    std::sync::Arc,
+    test_utils::{assert_error, create_vm, syscalls, TestContextObject},
+    thiserror::Error,
 };
-use std::sync::Arc;
-use test_utils::{assert_error, create_vm, syscalls, TestContextObject};
-use thiserror::Error;
 
 /// Error definitions
 #[derive(Debug, Error)]

--- a/tests/vm.rs
+++ b/tests/vm.rs
@@ -1,12 +1,14 @@
 #![allow(clippy::literal_string_with_formatting_args)]
 
-use solana_sbpf::{
-    elf::Executable,
-    program::BuiltinProgram,
-    vm::{Config, RuntimeEnvironmentSlot},
+use {
+    solana_sbpf::{
+        elf::Executable,
+        program::BuiltinProgram,
+        vm::{Config, RuntimeEnvironmentSlot},
+    },
+    std::{fs::File, io::Read, sync::Arc},
+    test_utils::{create_vm, syscalls, TestContextObject},
 };
-use std::{fs::File, io::Read, sync::Arc};
-use test_utils::{create_vm, syscalls, TestContextObject};
 
 #[test]
 fn test_runtime_environment_slots() {


### PR DESCRIPTION
### Description

As I started to look into `sbpf` code, noticed that there sometimes imports are under single use block, in others there is multiple separate ones. Decided to give it a try, maybe you would welcome this PR as my first to the repo.

### Summary of changes
- Imports across entire repo (where possible) got groupped under single `use` block.