### PR TITLE
fix: Correct ISA offset type to `i16`, clarify

### DIFF
--- a/doc/bytecode.md
+++ b/doc/bytecode.md
@@ -42,7 +42,7 @@ low byte                                          high byte
 | 3..=7     | operation code
 | 8..=11    | destination register
 | 12..=15   | source register
-| 16..=31   | offset
+| 16..=31   | offset (`i16`)
 | 32..=63   | immediate
 
 
@@ -75,7 +75,7 @@ Instructions by Class
 The following Rust equivalents assume that:
 - `src` and `dst` registers are `u64`
 - `imm` is `u32`
-- `off` is `u16`
+- `off` is `i16`
 
 ### Memory Load or 32 bit Arithmetic and Logic
 | opcode (hex / bin) | feature set | assembler mnemonic     | Rust equivalent


### PR DESCRIPTION
@Lichtso 

[`ebpf::Insn::off`](https://docs.rs/solana-sbpf/0.13.1/solana_sbpf/ebpf/struct.Insn.html#structfield.off) is an `i16`, but the ISA reports the corresponding Rust equivalent type as a `u16`, so fix the `u16` definition and add a clarification in the instruction layout

Related: https://github.com/blueshift-gg/sbpf/issues/97#issuecomment-3747603655