### PR TITLE
elf: make text section consistent with rodata

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -303,11 +303,20 @@ impl<C: ContextObject> Executable<C> {
     }
 
     /// Get the .text section virtual address and bytes
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn get_text_bytes(&self) -> (u64, &[u8]) {
-        (
-            self.text_section_vaddr,
-            &self.elf_bytes.as_slice()[self.text_section_range.clone()],
-        )
+        let text_len = self.text_section_range.len();
+        let text_bytes = match &self.ro_section {
+            // Use the owned data (not elf_bytes) to ensure the text section
+            // is consistent with the ro_section if the sections overlap.
+            Section::Owned(offset, data) => {
+                let text_offset = self.text_section_vaddr as usize - offset;
+                &data[text_offset..text_offset + text_len]
+            }
+            Section::Borrowed(_, _) => &self.elf_bytes.as_slice()[self.text_section_range.clone()],
+        };
+
+        (self.text_section_vaddr, text_bytes)
     }
 
     /// Get the concatenated read-only sections (including the text section)


### PR DESCRIPTION
Fixes an inconsistency in the elf loader, where if there are overlapping sections in the elf then the `text` section is different from the rearranged `ro` section:

- `get_text_bytes` uses the original relocated `elf_bytes`: https://github.com/anza-xyz/sbpf/blob/v0.14.4/src/elf.rs#L267-L273
- `get_ro_section` uses the rearranged `data` : https://github.com/anza-xyz/sbpf/blob/v0.14.4/src/elf.rs#L278

If the regions overlap, these two will be different and `text` will not be a subset of `rodata`.

This PR changes `get_text_bytes` to use the `rodata` bytes in the owned case, so that `rodata` and `text` are always consistent regardless of the ELF.

This change is safe because `Section::Owned` is only created if `sh_addr != sh_offset`, so this change has no affect on:
a) currently deployed mainnet programs, because there are no programs with `sh_addr != sh_offset`
b) new sbpf v0, v1 and v2 programs, as the elf deployment checks enforce that `sh_addr == sh_offset`
c) new spbf v3 programs, as there are no relocations