### PR TITLE
refactor: raw pointers/addresses for MemoryRegion construction

### DIFF
--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -313,8 +313,8 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation) {
     };
     let mut memory_mapping = MemoryMapping::new(
         vec![
-            MemoryRegion::new_writable(&mut mem1, vm_addr),
-            MemoryRegion::new_writable(&mut mem2, vm_addr + 8),
+            MemoryRegion::new_writable(&raw mut mem1[..], vm_addr),
+            MemoryRegion::new_writable(&raw mut mem2[..], vm_addr + 8),
         ],
         &config,
         SBPFVersion::V3,

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -69,7 +69,8 @@ macro_rules! bench_gapped_randomized_access_with_1024_entries {
                     let memory_regions =
                         vec![MemoryRegion::new(&raw const content[..], 0x100000000)];
                     let memory_mapping =
-                        MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
+                        unsafe { MemoryMapping::new(memory_regions, &config, SBPFVersion::V3) }
+                            .unwrap();
                     let mut prng = new_prng!();
                     bencher.iter(|| {
                         assert!(memory_mapping
@@ -111,7 +112,7 @@ macro_rules! bench_randomized_access_with_0001_entry {
                 ..Config::default()
             };
             let memory_mapping =
-                MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
+                unsafe { MemoryMapping::new(memory_regions, &config, SBPFVersion::V3) }.unwrap();
             let mut prng = new_prng!();
             bencher.iter(|| {
                 let _ = memory_mapping.map(
@@ -148,7 +149,7 @@ macro_rules! bench_randomized_access_with_n_entries {
                 ..Config::default()
             };
             let memory_mapping =
-                MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
+                unsafe { MemoryMapping::new(memory_regions, &config, SBPFVersion::V3) }.unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(
                     AccessType::Load,
@@ -198,7 +199,7 @@ macro_rules! bench_randomized_mapping_with_n_entries {
                 generate_memory_regions($n, false, Some(&mut prng));
             let config = Config::default();
             let memory_mapping =
-                MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
+                unsafe { MemoryMapping::new(memory_regions, &config, SBPFVersion::V3) }.unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(AccessType::Load, 0x100000000, 1);
             });
@@ -250,7 +251,7 @@ macro_rules! bench_mapping_with_n_entries {
                 ..Config::default()
             };
             let memory_mapping =
-                MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
+                unsafe { MemoryMapping::new(memory_regions, &config, SBPFVersion::V3) }.unwrap();
             bencher.iter(|| {
                 let _ = memory_mapping.map(AccessType::Load, 0x100000000, 1);
             });
@@ -306,14 +307,16 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation) {
         aligned_memory_mapping: false,
         ..Config::default()
     };
-    let mut memory_mapping = MemoryMapping::new(
-        vec![
-            MemoryRegion::new(&raw mut mem1[..], vm_addr),
-            MemoryRegion::new(&raw mut mem2[..], vm_addr + 8),
-        ],
-        &config,
-        SBPFVersion::V3,
-    )
+    let mut memory_mapping = unsafe {
+        MemoryMapping::new(
+            vec![
+                MemoryRegion::new(&raw mut mem1[..], vm_addr),
+                MemoryRegion::new(&raw mut mem2[..], vm_addr + 8),
+            ],
+            &config,
+            SBPFVersion::V3,
+        )
+    }
     .unwrap();
 
     match op {

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -30,13 +30,12 @@ fn generate_memory_regions(
             Some(prng) => (*prng).gen::<u8>() as u64 + 4,
             None => 4,
         };
-        let content = vec![0; length as usize];
-        memory_regions.push(MemoryRegion::new_for_testing(
-            &content[..],
-            offset,
-            0,
-            writable,
-        ));
+        let mut content = vec![0; length as usize];
+        if writable {
+            memory_regions.push(MemoryRegion::new(&raw mut content[..], offset));
+        } else {
+            memory_regions.push(MemoryRegion::new(&raw const content[..], offset));
+        }
         offset += 0x100000000;
     }
     (memory_regions, offset)
@@ -67,12 +66,8 @@ macro_rules! bench_gapped_randomized_access_with_1024_entries {
             };
             bencher
                 .bench(|bencher| {
-                    let memory_regions = vec![MemoryRegion::new_for_testing(
-                        &content[..],
-                        0x100000000,
-                        frame_size,
-                        false,
-                    )];
+                    let memory_regions =
+                        vec![MemoryRegion::new(&raw const content[..], 0x100000000)];
                     let memory_mapping =
                         MemoryMapping::new(memory_regions, &config, SBPFVersion::V3).unwrap();
                     let mut prng = new_prng!();
@@ -110,7 +105,7 @@ macro_rules! bench_randomized_access_with_0001_entry {
         #[bench]
         fn $name(bencher: &mut Bencher) {
             let content = vec![0; 1024 * 2];
-            let memory_regions = vec![MemoryRegion::new_readonly(&content[..], 0x100000000)];
+            let memory_regions = vec![MemoryRegion::new(&raw const content[..], 0x100000000)];
             let config = Config {
                 aligned_memory_mapping: $aligned_memory_mapping,
                 ..Config::default()
@@ -313,8 +308,8 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation) {
     };
     let mut memory_mapping = MemoryMapping::new(
         vec![
-            MemoryRegion::new_writable(&raw mut mem1[..], vm_addr),
-            MemoryRegion::new_writable(&raw mut mem2[..], vm_addr + 8),
+            MemoryRegion::new(&raw mut mem1[..], vm_addr),
+            MemoryRegion::new(&raw mut mem2[..], vm_addr + 8),
         ],
         &config,
         SBPFVersion::V3,

--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -66,8 +66,11 @@ macro_rules! bench_gapped_randomized_access_with_1024_entries {
             };
             bencher
                 .bench(|bencher| {
-                    let memory_regions =
-                        vec![MemoryRegion::new(&raw const content[..], 0x100000000)];
+                    let memory_regions = vec![MemoryRegion::new_gapped(
+                        &raw const content[..],
+                        0x100000000,
+                        frame_size,
+                    )];
                     let memory_mapping =
                         unsafe { MemoryMapping::new(memory_regions, &config, SBPFVersion::V3) }
                             .unwrap();

--- a/benches/vm_execution.rs
+++ b/benches/vm_execution.rs
@@ -88,7 +88,7 @@ fn bench_jit_vs_interpreter(
     assembly: &str,
     config: Config,
     instruction_meter: u64,
-    mem: &mut [u8],
+    mem: *mut [u8],
 ) {
     let executable = solana_sbpf::assembler::assemble::<TestContextObject>(
         assembly,
@@ -98,7 +98,7 @@ fn bench_jit_vs_interpreter(
     executable.verify::<RequisiteVerifier>().unwrap();
     executable.jit_compile().unwrap();
     let mut context_object = TestContextObject::default();
-    let mem_region = MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START);
+    let mem_region = MemoryRegion::new(mem, ebpf::MM_INPUT_START);
     create_vm!(
         vm,
         &executable,
@@ -310,7 +310,7 @@ fn bench_mem_ldxdw_jit(bencher: &mut Bencher) {
 
     let mut context_object = TestContextObject::default();
     let mut input = [0u8; 8];
-    let mem_region = MemoryRegion::new_writable(&mut input, ebpf::MM_INPUT_START);
+    let mem_region = MemoryRegion::new(&raw mut input, ebpf::MM_INPUT_START);
     create_vm!(
         vm,
         &executable,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
             },
         ),
         MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
-        MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START),
+        MemoryRegion::new_writable(&raw mut mem[..], ebpf::MM_INPUT_START),
     ];
 
     context_object.memory_mapping = MemoryMapping::new(regions, config, sbpf_version).unwrap();

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -163,7 +163,8 @@ fn main() {
         MemoryRegion::new(&raw mut mem[..], ebpf::MM_INPUT_START),
     ];
 
-    context_object.memory_mapping = MemoryMapping::new(regions, config, sbpf_version).unwrap();
+    context_object.memory_mapping =
+        unsafe { MemoryMapping::new(regions, config, sbpf_version).unwrap() };
 
     let mut vm = EbpfVm::new(
         executable.get_loader().clone(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -150,8 +150,8 @@ fn main() {
     );
     let regions: Vec<MemoryRegion> = vec![
         executable.get_ro_region(),
-        MemoryRegion::new_writable_gapped(
-            stack.as_slice_mut(),
+        MemoryRegion::new_gapped(
+            &raw mut *stack.as_slice_mut(),
             ebpf::MM_STACK_START,
             if sbpf_version.stack_frame_gaps() && config.enable_stack_frame_gaps {
                 config.stack_frame_size as u64
@@ -159,8 +159,8 @@ fn main() {
                 0
             },
         ),
-        MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
-        MemoryRegion::new_writable(&raw mut mem[..], ebpf::MM_INPUT_START),
+        MemoryRegion::new(&raw mut *heap.as_slice_mut(), ebpf::MM_HEAP_START),
+        MemoryRegion::new(&raw mut mem[..], ebpf::MM_INPUT_START),
     ];
 
     context_object.memory_mapping = MemoryMapping::new(regions, config, sbpf_version).unwrap();

--- a/fuzz/fuzz_targets/dumb_jit_diff.rs
+++ b/fuzz/fuzz_targets/dumb_jit_diff.rs
@@ -43,7 +43,7 @@ fuzz_target!(|data: DumbFuzzData| {
     .unwrap();
     let mut interp_mem = data.mem.clone();
     let mut interp_context_object = TestContextObject::new(1 << 16);
-    let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
+    let interp_mem_region = MemoryRegion::new(&raw mut interp_mem[..], ebpf::MM_INPUT_START);
     create_vm!(
         interp_vm,
         &executable,
@@ -67,7 +67,7 @@ fuzz_target!(|data: DumbFuzzData| {
     if executable.jit_compile().is_ok() {
         let mut jit_mem = data.mem.clone();
         let mut jit_context_object = TestContextObject::new(1 << 16);
-        let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
+        let jit_mem_region = MemoryRegion::new(&raw mut jit_mem[..], ebpf::MM_INPUT_START);
         create_vm!(
             jit_vm,
             &executable,

--- a/fuzz/fuzz_targets/dumb_verify.rs
+++ b/fuzz/fuzz_targets/dumb_verify.rs
@@ -43,7 +43,7 @@ fuzz_target!(|data: DumbFuzzData| {
         function_registry,
     )
     .unwrap();
-    let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
+    let mem_region = MemoryRegion::new(&raw mut mem[..], ebpf::MM_INPUT_START);
     let mut context_object = TestContextObject::new(1 << 4);
     create_vm!(
         interp_vm,

--- a/fuzz/fuzz_targets/elf_parser.rs
+++ b/fuzz/fuzz_targets/elf_parser.rs
@@ -37,7 +37,7 @@ fuzz_target!(|prog: &[u8]| {
     }
     let mut interp_mem = vec![0u8; 1 << 16];
     let mut interp_context_object = TestContextObject::new(1 << 16);
-    let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
+    let interp_mem_region = MemoryRegion::new(&raw mut interp_mem[..], ebpf::MM_INPUT_START);
     create_vm!(
         interp_vm,
         &executable,
@@ -62,7 +62,7 @@ fuzz_target!(|prog: &[u8]| {
     if executable.jit_compile().is_ok() {
         let mut jit_mem = vec![0u8; 1 << 16];
         let mut jit_context_object = TestContextObject::new(1 << 16);
-        let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
+        let jit_mem_region = MemoryRegion::new(&raw mut jit_mem[..], ebpf::MM_INPUT_START);
         create_vm!(
             jit_vm,
             &executable,

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -57,7 +57,7 @@ fuzz_target!(|data: FuzzData| {
     .unwrap();
     let mut interp_mem = data.mem.clone();
     let mut interp_context_object = TestContextObject::new(1 << 16);
-    let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
+    let interp_mem_region = MemoryRegion::new(&raw mut interp_mem[..], ebpf::MM_INPUT_START);
     create_vm!(
         interp_vm,
         &executable,
@@ -67,8 +67,7 @@ fuzz_target!(|data: FuzzData| {
         vec![interp_mem_region],
         None
     );
-    let mut interp_call_frames =
-        vec![CallFrame::default(); executable.get_config().max_call_depth];
+    let mut interp_call_frames = vec![CallFrame::default(); executable.get_config().max_call_depth];
     #[allow(unused)]
     let (_interp_ins_count, interp_res) = interp_vm.execute_program(
         &executable,
@@ -82,7 +81,7 @@ fuzz_target!(|data: FuzzData| {
     if executable.jit_compile().is_ok() {
         let mut jit_mem = data.mem.clone();
         let mut jit_context_object = TestContextObject::new(1 << 16);
-        let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
+        let jit_mem_region = MemoryRegion::new(&raw mut jit_mem[..], ebpf::MM_INPUT_START);
         create_vm!(
             jit_vm,
             &executable,

--- a/fuzz/fuzz_targets/smart_verify.rs
+++ b/fuzz/fuzz_targets/smart_verify.rs
@@ -46,7 +46,7 @@ fuzz_target!(|data: FuzzData| {
         function_registry,
     )
     .unwrap();
-    let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
+    let mem_region = MemoryRegion::new(&raw mut mem[..], ebpf::MM_INPUT_START);
     let mut context_object = TestContextObject::new(1 << 16);
     create_vm!(
         interp_vm,

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -46,7 +46,7 @@ fuzz_target!(|data: FuzzData| {
     .unwrap();
     let mut interp_mem = data.mem.clone();
     let mut interp_context_object = TestContextObject::new(1 << 16);
-    let interp_mem_region = MemoryRegion::new_writable(&mut interp_mem, ebpf::MM_INPUT_START);
+    let interp_mem_region = MemoryRegion::new(&raw mut interp_mem[..], ebpf::MM_INPUT_START);
     create_vm!(
         interp_vm,
         &executable,
@@ -70,7 +70,7 @@ fuzz_target!(|data: FuzzData| {
     if executable.jit_compile().is_ok() {
         let mut jit_mem = data.mem.clone();
         let mut jit_context_object = TestContextObject::new(1 << 16);
-        let jit_mem_region = MemoryRegion::new_writable(&mut jit_mem, ebpf::MM_INPUT_START);
+        let jit_mem_region = MemoryRegion::new(&raw mut jit_mem[..], ebpf::MM_INPUT_START);
         create_vm!(
             jit_vm,
             &executable,

--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -6,6 +6,8 @@ use std::{
     ptr::NonNull,
 };
 
+use crate::memory_region::HostMemoryObject;
+
 /// Scalar types, aka "plain old data"
 pub trait Pod: Copy {}
 
@@ -187,6 +189,26 @@ impl<const ALIGN: usize, T: AsRef<[u8]>> From<T> for AlignedMemory<ALIGN> {
     }
 }
 
+unsafe impl<const A: usize> HostMemoryObject for *const AlignedMemory<A> {
+    const WRITABLE: bool = false;
+    fn host_address(self) -> usize {
+        unsafe { (*self).mem.ptr.as_ptr().expose_provenance() }
+    }
+    fn byte_length(self) -> usize {
+        unsafe { (*self).len() }
+    }
+}
+
+unsafe impl<const A: usize> HostMemoryObject for *mut AlignedMemory<A> {
+    const WRITABLE: bool = true;
+    fn host_address(self) -> usize {
+        unsafe { (*self).mem.ptr.as_ptr().expose_provenance() }
+    }
+    fn byte_length(self) -> usize {
+        unsafe { (*self).len() }
+    }
+}
+
 /// Returns true if `ptr` is aligned to `align`.
 pub fn is_memory_aligned(ptr: usize, align: usize) -> bool {
     ptr.checked_rem(align)
@@ -261,7 +283,7 @@ impl<const ALIGN: usize> AlignedVec<ALIGN> {
     }
 
     fn as_slice(&self) -> &[u8] {
-        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr().cast_const(), self.length) }
+        unsafe { core::slice::from_raw_parts(self.ptr.as_ptr(), self.length) }
     }
 
     fn as_slice_mut(&mut self) -> &mut [u8] {

--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -189,23 +189,23 @@ impl<const ALIGN: usize, T: AsRef<[u8]>> From<T> for AlignedMemory<ALIGN> {
     }
 }
 
-unsafe impl<const A: usize> HostMemoryObject for *const AlignedMemory<A> {
+unsafe impl<const A: usize> HostMemoryObject for &AlignedMemory<A> {
     const WRITABLE: bool = false;
     fn host_address(self) -> usize {
-        unsafe { (*self).mem.ptr.as_ptr().expose_provenance() }
+        self.mem.ptr.as_ptr().expose_provenance()
     }
-    fn byte_length(self) -> usize {
-        unsafe { (*self).len() }
+    fn byte_length(&self) -> usize {
+        self.len()
     }
 }
 
-unsafe impl<const A: usize> HostMemoryObject for *mut AlignedMemory<A> {
+unsafe impl<const A: usize> HostMemoryObject for &mut AlignedMemory<A> {
     const WRITABLE: bool = true;
     fn host_address(self) -> usize {
-        unsafe { (*self).mem.ptr.as_ptr().expose_provenance() }
+        self.mem.ptr.as_ptr().expose_provenance()
     }
-    fn byte_length(self) -> usize {
-        unsafe { (*self).len() }
+    fn byte_length(&self) -> usize {
+        self.len()
     }
 }
 

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1275,5 +1275,5 @@ pub fn get_ro_region(ro_section: &Section, elf: &[u8]) -> MemoryRegion {
     // If offset > 0, the region will start at ebpf::MM_REGION_SIZE * 1 + the offset of
     // the first read only byte. [ebpf::MM_REGION_SIZE * 1, ebpf::MM_REGION_SIZE * 1 + offset)
     // will be unmappable, see MemoryRegion::vm_to_host.
-    MemoryRegion::new_readonly(ro_data, offset as u64)
+    MemoryRegion::new(&raw const *ro_data, offset as u64)
 }

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -59,7 +59,13 @@ pub struct MemoryRegion {
 }
 
 impl MemoryRegion {
-    fn new(slice: &[u8], vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
+    fn new_from_pointer(
+        pointer: u64,
+        len: u64,
+        vm_addr: u64,
+        vm_gap_size: u64,
+        writable: bool,
+    ) -> Self {
         let mut vm_gap_shift = (std::mem::size_of::<u64>() as u8)
             .saturating_mul(8)
             .saturating_sub(1);
@@ -68,13 +74,28 @@ impl MemoryRegion {
             debug_assert_eq!(Some(vm_gap_size), 1_u64.checked_shl(vm_gap_shift as u32));
         };
         MemoryRegion {
-            host_addr: slice.as_ptr() as u64,
+            host_addr: pointer,
             vm_addr,
-            len: slice.len() as u64,
+            len,
             vm_gap_shift,
             writable,
             access_violation_handler_payload: None,
         }
+    }
+
+    /// Used to create a region for an object other than a slice
+    pub fn new_readonly_gapless_from_pointer(pointer: u64, vm_addr: u64, len: u64) -> Self {
+        Self::new_from_pointer(pointer, len, vm_addr, 0, false)
+    }
+
+    fn new(slice: &[u8], vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
+        Self::new_from_pointer(
+            slice.as_ptr() as u64,
+            slice.len() as u64,
+            vm_addr,
+            vm_gap_size,
+            writable,
+        )
     }
 
     /// Only to be used in tests and benches

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -40,6 +40,101 @@ pub fn default_access_violation_handler(
 ) {
 }
 
+/// Types that can be used as backing memory for memory mappings.
+///
+/// ## Safety
+///
+/// The implementers must ensure that the returned address and byte length are contained by the
+/// implementing type's objects.
+pub unsafe trait HostMemoryObject: Copy {
+    /// Should the mapping region constructed by this object be considered writable?
+    const WRITABLE: bool;
+
+    /// The provenance-exposed address in the host address space for this object.
+    ///
+    /// Normally this is just an address of the pointer.
+    fn host_address(self) -> usize;
+    /// Number of contiguous bytes this object occupies.
+    fn byte_length(self) -> usize;
+}
+
+unsafe impl HostMemoryObject for *const [u8] {
+    const WRITABLE: bool = false;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(self) -> usize {
+        self.len()
+    }
+}
+
+unsafe impl HostMemoryObject for *mut [u8] {
+    const WRITABLE: bool = true;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(self) -> usize {
+        self.len()
+    }
+}
+
+unsafe impl<const N: usize> HostMemoryObject for *const [u8; N] {
+    const WRITABLE: bool = false;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(self) -> usize {
+        N
+    }
+}
+
+unsafe impl<const N: usize> HostMemoryObject for *mut [u8; N] {
+    const WRITABLE: bool = true;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(self) -> usize {
+        N
+    }
+}
+
+/// Types that can be directly mapped into VM memory space should implement this trait.
+///
+/// The blanket implementations of `HostMemoryObject` for `*const T` and `*mut T` where `T:
+/// VmExposable` allow exposing the implementing types to the guests directly.
+pub trait VmExposable {}
+
+/// Types that can be directly and mutably mapped into VM memory space.
+///
+/// The blanket implementations of `HostMemoryObject` for `*const T` and `*mut T` where `T:
+/// VmExposable` allow exposing the implementing types to the guests directly.
+///
+/// ## Safety
+///
+/// The type must not have any invariants that could be broken by the guest's modifications to the
+/// data within objects of this type.
+pub unsafe trait VmExposableMut {}
+
+unsafe impl<T: VmExposable> HostMemoryObject for *const T {
+    const WRITABLE: bool = false;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(self) -> usize {
+        std::mem::size_of::<T>()
+    }
+}
+
+unsafe impl<T: VmExposable> HostMemoryObject for *mut T {
+    const WRITABLE: bool = true;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(self) -> usize {
+        std::mem::size_of::<T>()
+    }
+}
+
 /// Memory region for bounds checking and address translation
 #[derive(Default, Eq, PartialEq, Clone)]
 #[repr(C, align(32))]
@@ -62,7 +157,13 @@ impl MemoryRegion {
     /// Create a VM memory region with host `address` pointing to a `len` bytes of data.
     ///
     /// This region will be made available in the guest at `vm_addr`.
-    fn new(address: usize, len: usize, vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
+    fn new_internal(
+        address: usize,
+        len: usize,
+        vm_addr: u64,
+        vm_gap_size: u64,
+        writable: bool,
+    ) -> Self {
         let mut vm_gap_shift = (std::mem::size_of::<u64>() as u8)
             .saturating_mul(8)
             .saturating_sub(1);
@@ -80,52 +181,29 @@ impl MemoryRegion {
         }
     }
 
-    /// Used to create a memory region for a host object.
-    pub fn new_readonly_object<T>(object: *const T, vm_addr: u64) -> Self {
-        Self::new(
-            object.expose_provenance() as _,
-            std::mem::size_of::<T>() as _,
+    /// Creates a new `MemoryRegion` backed by the provided host memory.
+    ///
+    /// The backing memory must remain allocated for the duration of the returned `MemoryRegion`.
+    pub fn new<HO: HostMemoryObject>(host: HO, vm_addr: u64) -> Self {
+        Self::new_internal(
+            host.host_address(),
+            host.byte_length(),
             vm_addr,
             0,
-            false,
+            HO::WRITABLE,
         )
     }
 
-    /// Only to be used in tests and benches
-    pub fn new_for_testing(slice: &[u8], vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
-        Self::new(
-            slice.as_ptr().expose_provenance(),
-            slice.len(),
+    /// Creates a new gapped `MemoryRegion` backed by the provided host memory.
+    ///
+    /// The backing memory must remain allocated for the duration of the returned `MemoryRegion`.
+    pub fn new_gapped<HO: HostMemoryObject>(host: HO, vm_addr: u64, vm_gap_size: u64) -> Self {
+        Self::new_internal(
+            host.host_address(),
+            host.byte_length(),
             vm_addr,
             vm_gap_size,
-            writable,
-        )
-    }
-
-    /// Creates a new readonly MemoryRegion from a slice.
-    ///
-    /// The backing data must remain allocated for the duration of the returned `MemoryRegion`.
-    pub fn new_readonly(slice: *const [u8], vm_addr: u64) -> Self {
-        Self::new(slice.expose_provenance(), slice.len(), vm_addr, 0, false)
-    }
-
-    /// Creates a new writable MemoryRegion from a mutable slice
-    ///
-    /// The backing data must remain allocated for the duration of the returned `MemoryRegion`.
-    pub fn new_writable(slice: *mut [u8], vm_addr: u64) -> Self {
-        Self::new(slice.expose_provenance(), slice.len(), vm_addr, 0, true)
-    }
-
-    /// Creates a new writable gapped MemoryRegion from a mutable slice
-    ///
-    /// The backing data must remain allocated for the duration of the returned `MemoryRegion`.
-    pub fn new_writable_gapped(slice: *mut [u8], vm_addr: u64, vm_gap_size: u64) -> Self {
-        Self::new(
-            slice.expose_provenance(),
-            slice.len(),
-            vm_addr,
-            vm_gap_size,
-            true,
+            HO::WRITABLE,
         )
     }
 
@@ -194,11 +272,13 @@ impl fmt::Debug for MemoryRegion {
         )
     }
 }
+
 impl std::cmp::PartialOrd for MemoryRegion {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
+
 impl std::cmp::Ord for MemoryRegion {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.vm_addr.cmp(&other.vm_addr)
@@ -357,6 +437,7 @@ impl AlignedMemoryMapping {
 
     /// Initialize the memory mapping by sorting its regions and filling gaps
     pub fn initialize(&mut self) -> Result<(), EbpfError> {
+        static EMPTY_SLICE: &[u8] = &[];
         if self.allow_memory_region_zero {
             self.regions.sort();
             let mut expected_region_index = 0;
@@ -371,8 +452,8 @@ impl AlignedMemoryMapping {
                 if actual_region_index > expected_region_index {
                     self.regions.insert(
                         expected_region_index,
-                        MemoryRegion::new_readonly(
-                            &[],
+                        MemoryRegion::new(
+                            &raw const *EMPTY_SLICE,
                             (expected_region_index as u64).saturating_mul(ebpf::MM_REGION_SIZE),
                         ),
                     );
@@ -382,7 +463,8 @@ impl AlignedMemoryMapping {
                 expected_region_index = expected_region_index.saturating_add(1);
             }
         } else {
-            self.regions.push(MemoryRegion::new_readonly(&[], 0));
+            self.regions
+                .push(MemoryRegion::new(&raw const *EMPTY_SLICE, 0));
             self.regions.sort();
             for (index, region) in self.regions.iter().enumerate() {
                 if region
@@ -849,14 +931,11 @@ mod test {
                 ..Config::default()
             };
             let mut mem1 = [0xff; 8];
+            let mem2 = [0; 8];
             let mut m = MemoryMapping::new(
                 vec![
-                    MemoryRegion::new_readonly(&[0; 8], ebpf::MM_REGION_SIZE),
-                    MemoryRegion::new_writable_gapped(
-                        &raw mut mem1[..],
-                        ebpf::MM_REGION_SIZE * 2,
-                        2,
-                    ),
+                    MemoryRegion::new(&raw const mem2[..], ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new_gapped(&raw mut mem1[..], ebpf::MM_REGION_SIZE * 2, 2),
                 ],
                 &config,
                 SBPFVersion::V3,
@@ -886,8 +965,11 @@ mod test {
         assert_error!(
             MemoryMapping::new(
                 vec![
-                    MemoryRegion::new_readonly(&mem1, ebpf::MM_REGION_SIZE),
-                    MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64 - 1),
+                    MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(
+                        &raw const mem2,
+                        ebpf::MM_REGION_SIZE + mem1.len() as u64 - 1
+                    ),
                 ],
                 &config,
                 SBPFVersion::V3,
@@ -896,8 +978,8 @@ mod test {
         );
         assert!(MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
             ],
             &config,
             SBPFVersion::V3,
@@ -917,14 +999,14 @@ mod test {
         let mem4 = [44, 44];
         let m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-                MemoryRegion::new_readonly(
-                    &mem3,
+                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                MemoryRegion::new(
+                    &raw const mem3,
                     ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len()) as u64,
                 ),
-                MemoryRegion::new_readonly(
-                    &mem4,
+                MemoryRegion::new(
+                    &raw const mem4,
                     ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len() + mem3.len()) as u64,
                 ),
             ],
@@ -999,8 +1081,8 @@ mod test {
         let mem2 = [0xDD; 4];
         let m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&raw const mem2[..], ebpf::MM_REGION_SIZE + 4),
+                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + 4),
             ],
             &config,
             SBPFVersion::V3,
@@ -1037,8 +1119,8 @@ mod test {
         let mem2 = [0xDD; 4];
         let m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&raw const mem2[..], ebpf::MM_REGION_SIZE * 2),
+                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE * 2),
             ],
             &config,
             SBPFVersion::V4,
@@ -1078,8 +1160,8 @@ mod test {
         let mem2 = [0x33];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
             ],
             &config,
             SBPFVersion::V3,
@@ -1101,11 +1183,8 @@ mod test {
         let mut mem2 = [0xff];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_writable(
-                    &raw mut mem2[..],
-                    ebpf::MM_REGION_SIZE + mem1.len() as u64,
-                ),
+                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw mut mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
             ],
             &config,
             SBPFVersion::V3,
@@ -1130,10 +1209,7 @@ mod test {
 
         let mut mem1 = [0xFF];
         let mut m = MemoryMapping::new(
-            vec![MemoryRegion::new_writable(
-                &raw mut mem1[..],
-                ebpf::MM_REGION_SIZE,
-            )],
+            vec![MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE)],
             &config,
             SBPFVersion::V3,
         )
@@ -1149,8 +1225,8 @@ mod test {
         let mut mem2 = [0xDD; 4];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_writable(&raw mut mem2[..], ebpf::MM_REGION_SIZE + 4),
+                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw mut mem2, ebpf::MM_REGION_SIZE + 4),
             ],
             &config,
             SBPFVersion::V3,
@@ -1171,10 +1247,7 @@ mod test {
 
         let mem1 = [0xff];
         let mut m = MemoryMapping::new(
-            vec![MemoryRegion::new_readonly(
-                &raw const mem1[..],
-                ebpf::MM_REGION_SIZE,
-            )],
+            vec![MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE)],
             &config,
             SBPFVersion::V3,
         )
@@ -1188,8 +1261,8 @@ mod test {
         let mem2 = [0xDD; 4];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&raw const mem1[..], ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&raw const mem2[..], ebpf::MM_REGION_SIZE + 4),
+                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + 4),
             ],
             &config,
             SBPFVersion::V3,
@@ -1209,11 +1282,8 @@ mod test {
         let mem2 = [0xff, 0xff];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(
-                    &raw const mem2[..],
-                    ebpf::MM_REGION_SIZE + mem1.len() as u64,
-                ),
+                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
             ],
             &config,
             SBPFVersion::V3,
@@ -1233,8 +1303,8 @@ mod test {
         let mem3 = [33];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
             ],
             &config,
             SBPFVersion::V3,
@@ -1259,7 +1329,7 @@ mod test {
         assert_error!(
             m.replace_region(
                 2,
-                MemoryRegion::new_readonly(&mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64)
+                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64)
             ),
             "InvalidMemoryRegion(2)"
         );
@@ -1274,7 +1344,10 @@ mod test {
         assert_error!(
             m.replace_region(
                 region_index,
-                MemoryRegion::new_readonly(&mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64 + 1)
+                MemoryRegion::new(
+                    &raw const mem3,
+                    ebpf::MM_REGION_SIZE + mem1.len() as u64 + 1
+                )
             ),
             "InvalidMemoryRegion({})",
             region_index
@@ -1282,7 +1355,7 @@ mod test {
 
         m.replace_region(
             region_index,
-            MemoryRegion::new_readonly(&mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+            MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64),
         )
         .unwrap();
 
@@ -1308,8 +1381,8 @@ mod test {
         let mem3 = [33, 33];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE * 2),
+                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE * 2),
             ],
             &config,
             SBPFVersion::V4,
@@ -1326,7 +1399,7 @@ mod test {
         assert_error!(
             m.replace_region(
                 3,
-                MemoryRegion::new_readonly(&mem3, ebpf::MM_REGION_SIZE * 2)
+                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 2)
             ),
             "InvalidMemoryRegion(3)"
         );
@@ -1335,7 +1408,7 @@ mod test {
         assert_error!(
             m.replace_region(
                 2,
-                MemoryRegion::new_readonly(&mem3, ebpf::MM_REGION_SIZE * 3)
+                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 3)
             ),
             "InvalidMemoryRegion(2)"
         );
@@ -1344,14 +1417,14 @@ mod test {
         assert_error!(
             m.replace_region(
                 2,
-                MemoryRegion::new_readonly(&mem3, ebpf::MM_REGION_SIZE * 3 - 1)
+                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 3 - 1)
             ),
             "InvalidMemoryRegion(2)"
         );
 
         m.replace_region(
             2,
-            MemoryRegion::new_readonly(&mem3, ebpf::MM_REGION_SIZE * 2),
+            MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 2),
         )
         .unwrap();
 
@@ -1371,7 +1444,7 @@ mod test {
             };
             let original = [11, 22];
             let copied = Rc::new(RefCell::new(Vec::new()));
-            let mut regions = vec![MemoryRegion::new_readonly(&original, ebpf::MM_REGION_SIZE)];
+            let mut regions = vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)];
             regions[0].access_violation_handler_payload = Some(0);
 
             let c = Rc::clone(&copied);
@@ -1409,7 +1482,7 @@ mod test {
             };
             let original = [11, 22];
             let copied = Rc::new(RefCell::new(Vec::new()));
-            let mut regions = vec![MemoryRegion::new_readonly(&original, ebpf::MM_REGION_SIZE)];
+            let mut regions = vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)];
             regions[0].access_violation_handler_payload = Some(0);
 
             let c = Rc::clone(&copied);
@@ -1453,8 +1526,8 @@ mod test {
             let copied = Rc::new(RefCell::new(Vec::new()));
 
             let mut regions = vec![
-                MemoryRegion::new_readonly(&original1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&original2, ebpf::MM_REGION_SIZE * 2),
+                MemoryRegion::new(&raw const original1, ebpf::MM_REGION_SIZE),
+                MemoryRegion::new(&raw const original2, ebpf::MM_REGION_SIZE * 2),
             ];
             regions[0].access_violation_handler_payload = Some(42);
 
@@ -1487,7 +1560,7 @@ mod test {
         let original = [11, 22];
 
         let m = MemoryMapping::new_with_access_violation_handler(
-            vec![MemoryRegion::new_readonly(&original, ebpf::MM_REGION_SIZE)],
+            vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)],
             &config,
             SBPFVersion::V4,
             Box::new(default_access_violation_handler),
@@ -1504,7 +1577,7 @@ mod test {
         let original = [11, 22];
 
         let mut m = MemoryMapping::new_with_access_violation_handler(
-            vec![MemoryRegion::new_readonly(&original, ebpf::MM_REGION_SIZE)],
+            vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)],
             &config,
             SBPFVersion::V4,
             Box::new(default_access_violation_handler),
@@ -1521,8 +1594,9 @@ mod test {
             ..Config::default()
         };
 
+        let mem = [11, 12];
         let mapping = MemoryMapping::new_with_access_violation_handler(
-            vec![MemoryRegion::new_readonly(&[11, 12], ebpf::MM_REGION_SIZE)],
+            vec![MemoryRegion::new(&raw const mem, ebpf::MM_REGION_SIZE)],
             &config,
             SBPFVersion::V4,
             Box::new(default_access_violation_handler),

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -46,7 +46,7 @@ pub fn default_access_violation_handler(
 ///
 /// The implementers must ensure that the returned address and byte length are contained by the
 /// implementing type's objects.
-pub unsafe trait HostMemoryObject: Copy {
+pub unsafe trait HostMemoryObject {
     /// Should the mapping region constructed by this object be considered writable?
     const WRITABLE: bool;
 
@@ -55,47 +55,7 @@ pub unsafe trait HostMemoryObject: Copy {
     /// Normally this is just an address of the pointer.
     fn host_address(self) -> usize;
     /// Number of contiguous bytes this object occupies.
-    fn byte_length(self) -> usize;
-}
-
-unsafe impl HostMemoryObject for *const [u8] {
-    const WRITABLE: bool = false;
-    fn host_address(self) -> usize {
-        self.expose_provenance()
-    }
-    fn byte_length(self) -> usize {
-        self.len()
-    }
-}
-
-unsafe impl HostMemoryObject for *mut [u8] {
-    const WRITABLE: bool = true;
-    fn host_address(self) -> usize {
-        self.expose_provenance()
-    }
-    fn byte_length(self) -> usize {
-        self.len()
-    }
-}
-
-unsafe impl<const N: usize> HostMemoryObject for *const [u8; N] {
-    const WRITABLE: bool = false;
-    fn host_address(self) -> usize {
-        self.expose_provenance()
-    }
-    fn byte_length(self) -> usize {
-        N
-    }
-}
-
-unsafe impl<const N: usize> HostMemoryObject for *mut [u8; N] {
-    const WRITABLE: bool = true;
-    fn host_address(self) -> usize {
-        self.expose_provenance()
-    }
-    fn byte_length(self) -> usize {
-        N
-    }
+    fn byte_length(&self) -> usize;
 }
 
 /// Types that can be directly mapped into VM memory space should implement this trait.
@@ -115,12 +75,15 @@ pub trait VmExposable {}
 /// data within objects of this type.
 pub unsafe trait VmExposableMut {}
 
+unsafe impl VmExposableMut for u8 {}
+impl<T: VmExposableMut> VmExposable for T {}
+
 unsafe impl<T: VmExposable> HostMemoryObject for *const T {
     const WRITABLE: bool = false;
     fn host_address(self) -> usize {
         self.expose_provenance()
     }
-    fn byte_length(self) -> usize {
+    fn byte_length(&self) -> usize {
         std::mem::size_of::<T>()
     }
 }
@@ -130,8 +93,48 @@ unsafe impl<T: VmExposable> HostMemoryObject for *mut T {
     fn host_address(self) -> usize {
         self.expose_provenance()
     }
-    fn byte_length(self) -> usize {
+    fn byte_length(&self) -> usize {
         std::mem::size_of::<T>()
+    }
+}
+
+unsafe impl<T: VmExposable> HostMemoryObject for *const [T] {
+    const WRITABLE: bool = false;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(&self) -> usize {
+        self.len().checked_mul(core::mem::size_of::<T>()).unwrap()
+    }
+}
+
+unsafe impl<T: VmExposableMut> HostMemoryObject for *mut [T] {
+    const WRITABLE: bool = true;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(&self) -> usize {
+        self.len().checked_mul(core::mem::size_of::<T>()).unwrap()
+    }
+}
+
+unsafe impl<T: VmExposableMut, const N: usize> HostMemoryObject for *const [T; N] {
+    const WRITABLE: bool = false;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(&self) -> usize {
+        N.checked_mul(core::mem::size_of::<T>()).unwrap()
+    }
+}
+
+unsafe impl<T: VmExposable, const N: usize> HostMemoryObject for *mut [T; N] {
+    const WRITABLE: bool = true;
+    fn host_address(self) -> usize {
+        self.expose_provenance()
+    }
+    fn byte_length(&self) -> usize {
+        N.checked_mul(core::mem::size_of::<T>()).unwrap()
     }
 }
 
@@ -185,26 +188,17 @@ impl MemoryRegion {
     ///
     /// The backing memory must remain allocated for the duration of the returned `MemoryRegion`.
     pub fn new<HO: HostMemoryObject>(host: HO, vm_addr: u64) -> Self {
-        Self::new_internal(
-            host.host_address(),
-            host.byte_length(),
-            vm_addr,
-            0,
-            HO::WRITABLE,
-        )
+        let bytes = host.byte_length();
+        Self::new_internal(host.host_address(), bytes, vm_addr, 0, HO::WRITABLE)
     }
 
     /// Creates a new gapped `MemoryRegion` backed by the provided host memory.
     ///
     /// The backing memory must remain allocated for the duration of the returned `MemoryRegion`.
     pub fn new_gapped<HO: HostMemoryObject>(host: HO, vm_addr: u64, vm_gap_size: u64) -> Self {
-        Self::new_internal(
-            host.host_address(),
-            host.byte_length(),
-            vm_addr,
-            vm_gap_size,
-            HO::WRITABLE,
-        )
+        let bytes = host.byte_length();
+        let host_address = host.host_address();
+        Self::new_internal(host_address, bytes, vm_addr, vm_gap_size, HO::WRITABLE)
     }
 
     /// Returns the vm address space covered by this MemoryRegion
@@ -331,7 +325,11 @@ impl UnalignedMemoryMapping {
     }
 
     /// Create an uninitialized UnalignedMapping
-    pub fn new_uninitialized(regions: Vec<MemoryRegion>) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
+    pub unsafe fn new_uninitialized(regions: Vec<MemoryRegion>) -> Self {
         let number_of_regions = regions.len();
         Self {
             regions: regions.into_boxed_slice(),
@@ -342,7 +340,11 @@ impl UnalignedMemoryMapping {
     }
 
     /// Creates a new MemoryMapping structure from the given regions
-    pub fn new(regions: Vec<MemoryRegion>) -> Result<Self, EbpfError> {
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
+    pub unsafe fn new(regions: Vec<MemoryRegion>) -> Result<Self, EbpfError> {
         let mut mapping = Self::new_uninitialized(regions);
         mapping.initialize()?;
         Ok(mapping)
@@ -403,8 +405,16 @@ impl UnalignedMemoryMapping {
     }
 
     /// Replaces the `MemoryRegion` at the given index
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
     #[inline(always)]
-    pub fn replace_region(&mut self, index: usize, region: MemoryRegion) -> Result<(), EbpfError> {
+    pub unsafe fn replace_region(
+        &mut self,
+        index: usize,
+        region: MemoryRegion,
+    ) -> Result<(), EbpfError> {
         self.regions[index] = region;
         self.cache.get_mut().flush();
         Ok(())
@@ -421,14 +431,22 @@ pub struct AlignedMemoryMapping {
 
 impl AlignedMemoryMapping {
     /// Creates a new initialized MemoryMapping structure from the given regions
-    pub fn new(regions: Vec<MemoryRegion>, config: &Config) -> Result<Self, EbpfError> {
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
+    pub unsafe fn new(regions: Vec<MemoryRegion>, config: &Config) -> Result<Self, EbpfError> {
         let mut mapping = Self::new_uninitialized(regions, config);
         mapping.initialize()?;
         Ok(mapping)
     }
 
     /// Create an uninitialized MemoryMapping
-    pub fn new_uninitialized(regions: Vec<MemoryRegion>, config: &Config) -> Self {
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
+    pub unsafe fn new_uninitialized(regions: Vec<MemoryRegion>, config: &Config) -> Self {
         Self {
             regions,
             allow_memory_region_zero: config.allow_memory_region_zero,
@@ -494,8 +512,16 @@ impl AlignedMemoryMapping {
     }
 
     /// Replaces the `MemoryRegion` at the given index
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
     #[inline(always)]
-    pub fn replace_region(&mut self, index: usize, region: MemoryRegion) -> Result<(), EbpfError> {
+    pub unsafe fn replace_region(
+        &mut self,
+        index: usize,
+        region: MemoryRegion,
+    ) -> Result<(), EbpfError> {
         let begin_index = region
             .vm_addr
             .checked_shr(ebpf::VIRTUAL_ADDRESS_BITS as u32)
@@ -552,7 +578,14 @@ impl MemoryMapping {
     ///
     /// Uses aligned or unaligned memory mapping depending on the value of
     /// `config.aligned_memory_mapping=true`.
-    pub fn new_with_access_violation_handler(
+    ///
+    /// # Safety
+    ///
+    /// In addition to the requirements of [`MemoryMapping::new_uninitialized`], the provided
+    /// `access_violation_handler` must return with its [`MemoryRegion`] unmodified, or initialized
+    /// to another equally correct [`MemoryRegion`] as described in the safety invariants for
+    /// `new_uninitialized`.
+    pub unsafe fn new_with_access_violation_handler(
         regions: Vec<MemoryRegion>,
         config: &Config,
         sbpf_version: SBPFVersion,
@@ -565,7 +598,16 @@ impl MemoryMapping {
     }
 
     /// Creates an unitialized memory mapping
-    pub fn new_uninitialized(
+    ///
+    /// # Safety
+    ///
+    /// The memory pointed to by the [`MemoryRegion`]s must point to a valid object live for the
+    /// duration of this `MemoryMapping`.
+    ///
+    /// For `MemoryRegion`s marked writable, the memory pointed to by the memory region must accept
+    /// arbitrary bytes being overwritten without it resulting in unsoundness (due to e.g. broken
+    /// internal type invariants.)
+    pub unsafe fn new_uninitialized(
         regions: Vec<MemoryRegion>,
         config: &Config,
         sbpf_version: SBPFVersion,
@@ -595,7 +637,11 @@ impl MemoryMapping {
     /// Creates a new memory mapping for tests and benches.
     ///
     /// `access_violation_handler` defaults to a function which always returns an error.
-    pub fn new(
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
+    pub unsafe fn new(
         regions: Vec<MemoryRegion>,
         config: &Config,
         sbpf_version: SBPFVersion,
@@ -651,7 +697,7 @@ impl MemoryMapping {
                 .saturating_sub(region.vm_addr);
             (self.access_violation_handler)(&mut region, max_len, access_type, vm_addr, len);
             if let Some(host_addr) = region.vm_to_host(access_type, vm_addr, len) {
-                if let Err(err) = self.replace_region(index, region) {
+                if let Err(err) = unsafe { self.replace_region(index, region) } {
                     return ProgramResult::Err(err);
                 }
                 return ProgramResult::Ok(host_addr);
@@ -724,8 +770,16 @@ impl MemoryMapping {
     }
 
     /// Replaces the `MemoryRegion` at the given index
+    ///
+    /// # Safety
+    ///
+    /// Refer to [`MemoryMapping::new_uninitialized`].
     #[inline(always)]
-    pub fn replace_region(&mut self, index: usize, region: MemoryRegion) -> Result<(), EbpfError> {
+    pub unsafe fn replace_region(
+        &mut self,
+        index: usize,
+        region: MemoryRegion,
+    ) -> Result<(), EbpfError> {
         debug_assert!(self.initialized);
         let regions = self.get_regions();
         let next_region_start = regions
@@ -915,7 +969,7 @@ mod test {
                 aligned_memory_mapping,
                 ..Config::default()
             };
-            let m = MemoryMapping::new(vec![], &config, SBPFVersion::V3).unwrap();
+            let m = unsafe { MemoryMapping::new(vec![], &config, SBPFVersion::V3) }.unwrap();
             assert_error!(
                 m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 8),
                 "AccessViolation"
@@ -932,15 +986,17 @@ mod test {
             };
             let mut mem1 = [0xff; 8];
             let mem2 = [0; 8];
-            let mut m = MemoryMapping::new(
-                vec![
-                    MemoryRegion::new(&raw const mem2[..], ebpf::MM_REGION_SIZE),
-                    MemoryRegion::new_gapped(&raw mut mem1[..], ebpf::MM_REGION_SIZE * 2, 2),
-                ],
-                &config,
-                SBPFVersion::V3,
-            )
-            .unwrap();
+            let mut m = unsafe {
+                MemoryMapping::new(
+                    vec![
+                        MemoryRegion::new(&raw const mem2[..], ebpf::MM_REGION_SIZE),
+                        MemoryRegion::new_gapped(&raw mut mem1[..], ebpf::MM_REGION_SIZE * 2, 2),
+                    ],
+                    &config,
+                    SBPFVersion::V3,
+                )
+                .unwrap()
+            };
             for frame in 0..4 {
                 let address = ebpf::MM_STACK_START + frame * 4;
                 assert!(m.find_region(address).is_some());
@@ -963,27 +1019,31 @@ mod test {
         let mem1 = [1, 2, 3, 4];
         let mem2 = [5, 6];
         assert_error!(
+            unsafe {
+                MemoryMapping::new(
+                    vec![
+                        MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                        MemoryRegion::new(
+                            &raw const mem2,
+                            ebpf::MM_REGION_SIZE + mem1.len() as u64 - 1,
+                        ),
+                    ],
+                    &config,
+                    SBPFVersion::V3,
+                )
+            },
+            "InvalidMemoryRegion(1)"
+        );
+        assert!(unsafe {
             MemoryMapping::new(
                 vec![
                     MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
-                    MemoryRegion::new(
-                        &raw const mem2,
-                        ebpf::MM_REGION_SIZE + mem1.len() as u64 - 1
-                    ),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
                 ],
                 &config,
                 SBPFVersion::V3,
-            ),
-            "InvalidMemoryRegion(1)"
-        );
-        assert!(MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
+            )
+        }
         .is_ok());
     }
 
@@ -997,23 +1057,25 @@ mod test {
         let mem2 = [22, 22];
         let mem3 = [33];
         let mem4 = [44, 44];
-        let m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-                MemoryRegion::new(
-                    &raw const mem3,
-                    ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len()) as u64,
-                ),
-                MemoryRegion::new(
-                    &raw const mem4,
-                    ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len() + mem3.len()) as u64,
-                ),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                    MemoryRegion::new(
+                        &raw const mem3,
+                        ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len()) as u64,
+                    ),
+                    MemoryRegion::new(
+                        &raw const mem4,
+                        ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len() + mem3.len()) as u64,
+                    ),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
 
         assert_eq!(
             m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1).unwrap(),
@@ -1079,15 +1141,17 @@ mod test {
 
         let mut mem1 = [0xFF; 4];
         let mem2 = [0xDD; 4];
-        let m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + 4),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + 4),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
         assert!(m.find_region(ebpf::MM_REGION_SIZE - 1).is_none());
         assert_eq!(
             m.find_region(ebpf::MM_REGION_SIZE).unwrap().1.host_addr,
@@ -1117,15 +1181,17 @@ mod test {
 
         let mut mem1 = [0xFF; 4];
         let mem2 = [0xDD; 4];
-        let m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE * 2),
-            ],
-            &config,
-            SBPFVersion::V4,
-        )
-        .unwrap();
+        let m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE * 2),
+                ],
+                &config,
+                SBPFVersion::V4,
+            )
+            .unwrap()
+        };
         assert_eq!(m.find_region(ebpf::MM_REGION_SIZE - 1).unwrap().1.len, 0);
         assert_eq!(
             m.find_region(ebpf::MM_REGION_SIZE).unwrap().1.host_addr,
@@ -1158,15 +1224,17 @@ mod test {
         };
         let mem1 = [0x11, 0x22];
         let mem2 = [0x33];
-        let mut m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
 
         assert_eq!(m.load::<u16>(ebpf::MM_REGION_SIZE).unwrap(), 0x2211);
         assert_error!(m.load::<u32>(ebpf::MM_REGION_SIZE), "AccessViolation");
@@ -1181,15 +1249,17 @@ mod test {
         };
         let mut mem1 = [0xff, 0xff];
         let mut mem2 = [0xff];
-        let mut m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw mut mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw mut mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
 
         m.store(0x1122u16, ebpf::MM_REGION_SIZE).unwrap();
         assert_eq!(m.load::<u16>(ebpf::MM_REGION_SIZE).unwrap(), 0x1122);
@@ -1208,12 +1278,14 @@ mod test {
         };
 
         let mut mem1 = [0xFF];
-        let mut m = MemoryMapping::new(
-            vec![MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE)],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE)],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
         m.store(0x11u8, ebpf::MM_REGION_SIZE).unwrap();
         assert_error!(m.store(0x11u8, ebpf::MM_REGION_SIZE - 1), "AccessViolation");
         assert_error!(m.store(0x11u8, ebpf::MM_REGION_SIZE + 1), "AccessViolation");
@@ -1223,15 +1295,17 @@ mod test {
 
         let mut mem1 = [0xFF; 4];
         let mut mem2 = [0xDD; 4];
-        let mut m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw mut mem2, ebpf::MM_REGION_SIZE + 4),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw mut mem2, ebpf::MM_REGION_SIZE + 4),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
         assert_error!(
             m.store(0x1122334455667788u64, ebpf::MM_REGION_SIZE),
             "AccessViolation"
@@ -1246,12 +1320,14 @@ mod test {
         };
 
         let mem1 = [0xff];
-        let mut m = MemoryMapping::new(
-            vec![MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE)],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE)],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
         assert_eq!(m.load::<u8>(ebpf::MM_REGION_SIZE).unwrap(), 0xff);
         assert_error!(m.load::<u8>(ebpf::MM_REGION_SIZE - 1), "AccessViolation");
         assert_error!(m.load::<u8>(ebpf::MM_REGION_SIZE + 1), "AccessViolation");
@@ -1259,15 +1335,17 @@ mod test {
 
         let mem1 = [0xFF; 4];
         let mem2 = [0xDD; 4];
-        let mut m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + 4),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + 4),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
         assert_error!(m.load::<u64>(ebpf::MM_REGION_SIZE), "AccessViolation");
     }
 
@@ -1280,15 +1358,17 @@ mod test {
         };
         let mut mem1 = [0xff, 0xff];
         let mem2 = [0xff, 0xff];
-        let mut m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw mut mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
         m.store(0x11223344, ebpf::MM_REGION_SIZE).unwrap();
     }
 
@@ -1301,15 +1381,17 @@ mod test {
         let mem1 = [11];
         let mem2 = [22, 22];
         let mem3 = [33];
-        let mut m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-            ],
-            &config,
-            SBPFVersion::V3,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                ],
+                &config,
+                SBPFVersion::V3,
+            )
+            .unwrap()
+        };
 
         assert_eq!(
             m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1).unwrap(),
@@ -1327,10 +1409,12 @@ mod test {
         );
 
         assert_error!(
-            m.replace_region(
-                2,
-                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64)
-            ),
+            unsafe {
+                m.replace_region(
+                    2,
+                    MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                )
+            },
             "InvalidMemoryRegion(2)"
         );
 
@@ -1342,22 +1426,26 @@ mod test {
 
         // old.vm_addr != new.vm_addr
         assert_error!(
-            m.replace_region(
-                region_index,
-                MemoryRegion::new(
-                    &raw const mem3,
-                    ebpf::MM_REGION_SIZE + mem1.len() as u64 + 1
+            unsafe {
+                m.replace_region(
+                    region_index,
+                    MemoryRegion::new(
+                        &raw const mem3,
+                        ebpf::MM_REGION_SIZE + mem1.len() as u64 + 1,
+                    ),
                 )
-            ),
+            },
             "InvalidMemoryRegion({})",
             region_index
         );
 
-        m.replace_region(
-            region_index,
-            MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64),
-        )
-        .unwrap();
+        unsafe {
+            m.replace_region(
+                region_index,
+                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+            )
+            .unwrap()
+        };
 
         assert_eq!(
             m.map(
@@ -1379,15 +1467,17 @@ mod test {
         let mem1 = [11];
         let mem2 = [22, 22];
         let mem3 = [33, 33];
-        let mut m = MemoryMapping::new(
-            vec![
-                MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE * 2),
-            ],
-            &config,
-            SBPFVersion::V4,
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![
+                    MemoryRegion::new(&raw const mem1, ebpf::MM_REGION_SIZE),
+                    MemoryRegion::new(&raw const mem2, ebpf::MM_REGION_SIZE * 2),
+                ],
+                &config,
+                SBPFVersion::V4,
+            )
+            .unwrap()
+        };
 
         assert_eq!(
             m.map(AccessType::Load, ebpf::MM_REGION_SIZE * 2, 1)
@@ -1397,36 +1487,44 @@ mod test {
 
         // index > regions.len()
         assert_error!(
-            m.replace_region(
-                3,
-                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 2)
-            ),
+            unsafe {
+                m.replace_region(
+                    3,
+                    MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 2),
+                )
+            },
             "InvalidMemoryRegion(3)"
         );
 
         // index != addr >> VIRTUAL_ADDRESS_BITS
         assert_error!(
-            m.replace_region(
-                2,
-                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 3)
-            ),
+            unsafe {
+                m.replace_region(
+                    2,
+                    MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 3),
+                )
+            },
             "InvalidMemoryRegion(2)"
         );
 
         // index + len != addr >> VIRTUAL_ADDRESS_BITS
         assert_error!(
-            m.replace_region(
-                2,
-                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 3 - 1)
-            ),
+            unsafe {
+                m.replace_region(
+                    2,
+                    MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 3 - 1),
+                )
+            },
             "InvalidMemoryRegion(2)"
         );
 
-        m.replace_region(
-            2,
-            MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 2),
-        )
-        .unwrap();
+        unsafe {
+            m.replace_region(
+                2,
+                MemoryRegion::new(&raw const mem3, ebpf::MM_REGION_SIZE * 2),
+            )
+            .unwrap()
+        };
 
         assert_eq!(
             m.map(AccessType::Load, ebpf::MM_REGION_SIZE * 2, 1)
@@ -1448,17 +1546,19 @@ mod test {
             regions[0].access_violation_handler_payload = Some(0);
 
             let c = Rc::clone(&copied);
-            let mut m = MemoryMapping::new_with_access_violation_handler(
-                regions,
-                &config,
-                SBPFVersion::V3,
-                Box::new(move |region, _, _, _, _| {
-                    c.borrow_mut().extend_from_slice(&original);
-                    region.writable = true;
-                    region.host_addr = c.borrow().as_slice().as_ptr() as u64;
-                }),
-            )
-            .unwrap();
+            let mut m = unsafe {
+                MemoryMapping::new_with_access_violation_handler(
+                    regions,
+                    &config,
+                    SBPFVersion::V3,
+                    Box::new(move |region, _, _, _, _| {
+                        c.borrow_mut().extend_from_slice(&original);
+                        region.writable = true;
+                        region.host_addr = c.borrow().as_slice().as_ptr() as u64;
+                    }),
+                )
+                .unwrap()
+            };
 
             assert_eq!(
                 m.map_with_access_violation_handler(AccessType::Load, ebpf::MM_REGION_SIZE, 1)
@@ -1486,17 +1586,19 @@ mod test {
             regions[0].access_violation_handler_payload = Some(0);
 
             let c = Rc::clone(&copied);
-            let mut m = MemoryMapping::new_with_access_violation_handler(
-                regions,
-                &config,
-                SBPFVersion::V3,
-                Box::new(move |region, _, _, _, _| {
-                    c.borrow_mut().extend_from_slice(&original);
-                    region.writable = true;
-                    region.host_addr = c.borrow().as_slice().as_ptr() as u64;
-                }),
-            )
-            .unwrap();
+            let mut m = unsafe {
+                MemoryMapping::new_with_access_violation_handler(
+                    regions,
+                    &config,
+                    SBPFVersion::V3,
+                    Box::new(move |region, _, _, _, _| {
+                        c.borrow_mut().extend_from_slice(&original);
+                        region.writable = true;
+                        region.host_addr = c.borrow().as_slice().as_ptr() as u64;
+                    }),
+                )
+                .unwrap()
+            };
 
             assert_eq!(
                 m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1).unwrap(),
@@ -1532,20 +1634,22 @@ mod test {
             regions[0].access_violation_handler_payload = Some(42);
 
             let c = Rc::clone(&copied);
-            let mut m = MemoryMapping::new_with_access_violation_handler(
-                regions,
-                &config,
-                SBPFVersion::V3,
-                Box::new(move |region, _, _, _, _| {
-                    // check that the argument passed to MemoryRegion::new_readonly is then passed to the
-                    // callback
-                    assert_eq!(region.access_violation_handler_payload, Some(42));
-                    c.borrow_mut().extend_from_slice(&original1);
-                    region.writable = true;
-                    region.host_addr = c.borrow().as_slice().as_ptr() as u64;
-                }),
-            )
-            .unwrap();
+            let mut m = unsafe {
+                MemoryMapping::new_with_access_violation_handler(
+                    regions,
+                    &config,
+                    SBPFVersion::V3,
+                    Box::new(move |region, _, _, _, _| {
+                        // check that the argument passed to MemoryRegion::new_readonly is then passed to the
+                        // callback
+                        assert_eq!(region.access_violation_handler_payload, Some(42));
+                        c.borrow_mut().extend_from_slice(&original1);
+                        region.writable = true;
+                        region.host_addr = c.borrow().as_slice().as_ptr() as u64;
+                    }),
+                )
+                .unwrap()
+            };
 
             m.store(55u8, ebpf::MM_REGION_SIZE).unwrap();
             assert_eq!(original1[0], 11);
@@ -1559,13 +1663,15 @@ mod test {
         let config = Config::default();
         let original = [11, 22];
 
-        let m = MemoryMapping::new_with_access_violation_handler(
-            vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)],
-            &config,
-            SBPFVersion::V4,
-            Box::new(default_access_violation_handler),
-        )
-        .unwrap();
+        let m = unsafe {
+            MemoryMapping::new_with_access_violation_handler(
+                vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)],
+                &config,
+                SBPFVersion::V4,
+                Box::new(default_access_violation_handler),
+            )
+            .unwrap()
+        };
 
         m.map(AccessType::Store, ebpf::MM_REGION_SIZE, 1).unwrap();
     }
@@ -1576,13 +1682,15 @@ mod test {
         let config = Config::default();
         let original = [11, 22];
 
-        let mut m = MemoryMapping::new_with_access_violation_handler(
-            vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)],
-            &config,
-            SBPFVersion::V4,
-            Box::new(default_access_violation_handler),
-        )
-        .unwrap();
+        let mut m = unsafe {
+            MemoryMapping::new_with_access_violation_handler(
+                vec![MemoryRegion::new(&raw const original, ebpf::MM_REGION_SIZE)],
+                &config,
+                SBPFVersion::V4,
+                Box::new(default_access_violation_handler),
+            )
+            .unwrap()
+        };
 
         m.store(33u8, ebpf::MM_REGION_SIZE).unwrap();
     }
@@ -1595,13 +1703,15 @@ mod test {
         };
 
         let mem = [11, 12];
-        let mapping = MemoryMapping::new_with_access_violation_handler(
-            vec![MemoryRegion::new(&raw const mem, ebpf::MM_REGION_SIZE)],
-            &config,
-            SBPFVersion::V4,
-            Box::new(default_access_violation_handler),
-        )
-        .unwrap();
+        let mapping = unsafe {
+            MemoryMapping::new_with_access_violation_handler(
+                vec![MemoryRegion::new(&raw const mem, ebpf::MM_REGION_SIZE)],
+                &config,
+                SBPFVersion::V4,
+                Box::new(default_access_violation_handler),
+            )
+            .unwrap()
+        };
 
         assert!(matches!(mapping.ty, MemoryMappingType::Aligned(_)));
     }

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -60,14 +60,14 @@ pub unsafe trait HostMemoryObject {
 
 /// Types that can be directly mapped into VM memory space should implement this trait.
 ///
-/// The blanket implementations of `HostMemoryObject` for `*const T` and `*mut T` where `T:
-/// VmExposable` allow exposing the implementing types to the guests directly.
+/// The blanket implementations of [`HostMemoryObject`] for `*const T` where `T: VmExposable` allow
+/// exposing the implementing types to the guests directly.
 pub trait VmExposable {}
 
 /// Types that can be directly and mutably mapped into VM memory space.
 ///
-/// The blanket implementations of `HostMemoryObject` for `*const T` and `*mut T` where `T:
-/// VmExposable` allow exposing the implementing types to the guests directly.
+/// The blanket implementations of [`HostMemoryObject`] for `*mut T` where `T: VmExposableMut` allow
+/// mutably exposing the implementing types to the guests directly.
 ///
 /// ## Safety
 ///

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -848,7 +848,7 @@ mod test {
                 aligned_memory_mapping,
                 ..Config::default()
             };
-            let mut mem1 = vec![0xff; 8];
+            let mut mem1 = [0xff; 8];
             let mut m = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_readonly(&[0; 8], ebpf::MM_REGION_SIZE),
@@ -995,8 +995,8 @@ mod test {
             ..Config::default()
         };
 
-        let mut mem1 = vec![0xFF; 4];
-        let mem2 = vec![0xDD; 4];
+        let mut mem1 = [0xFF; 4];
+        let mem2 = [0xDD; 4];
         let m = MemoryMapping::new(
             vec![
                 MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
@@ -1033,8 +1033,8 @@ mod test {
             ..Config::default()
         };
 
-        let mut mem1 = vec![0xFF; 4];
-        let mem2 = vec![0xDD; 4];
+        let mut mem1 = [0xFF; 4];
+        let mem2 = [0xDD; 4];
         let m = MemoryMapping::new(
             vec![
                 MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
@@ -1097,8 +1097,8 @@ mod test {
             aligned_memory_mapping: false,
             ..Config::default()
         };
-        let mut mem1 = vec![0xff, 0xff];
-        let mut mem2 = vec![0xff];
+        let mut mem1 = [0xff, 0xff];
+        let mut mem2 = [0xff];
         let mut m = MemoryMapping::new(
             vec![
                 MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
@@ -1128,7 +1128,7 @@ mod test {
             ..Config::default()
         };
 
-        let mut mem1 = vec![0xFF];
+        let mut mem1 = [0xFF];
         let mut m = MemoryMapping::new(
             vec![MemoryRegion::new_writable(
                 &raw mut mem1[..],
@@ -1145,8 +1145,8 @@ mod test {
         // outside the address space (the case above is just on the edge)
         assert_error!(m.store(0x11u8, ebpf::MM_REGION_SIZE + 2), "AccessViolation");
 
-        let mut mem1 = vec![0xFF; 4];
-        let mut mem2 = vec![0xDD; 4];
+        let mut mem1 = [0xFF; 4];
+        let mut mem2 = [0xDD; 4];
         let mut m = MemoryMapping::new(
             vec![
                 MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
@@ -1169,7 +1169,7 @@ mod test {
             ..Config::default()
         };
 
-        let mem1 = vec![0xff];
+        let mem1 = [0xff];
         let mut m = MemoryMapping::new(
             vec![MemoryRegion::new_readonly(
                 &raw const mem1[..],
@@ -1184,8 +1184,8 @@ mod test {
         assert_error!(m.load::<u8>(ebpf::MM_REGION_SIZE + 1), "AccessViolation");
         assert_error!(m.load::<u8>(ebpf::MM_REGION_SIZE + 2), "AccessViolation");
 
-        let mem1 = vec![0xFF; 4];
-        let mem2 = vec![0xDD; 4];
+        let mem1 = [0xFF; 4];
+        let mem2 = [0xDD; 4];
         let mut m = MemoryMapping::new(
             vec![
                 MemoryRegion::new_readonly(&raw const mem1[..], ebpf::MM_REGION_SIZE),
@@ -1205,8 +1205,8 @@ mod test {
             aligned_memory_mapping: false,
             ..Config::default()
         };
-        let mut mem1 = vec![0xff, 0xff];
-        let mem2 = vec![0xff, 0xff];
+        let mut mem1 = [0xff, 0xff];
+        let mem2 = [0xff, 0xff];
         let mut m = MemoryMapping::new(
             vec![
                 MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -1640,7 +1640,7 @@ mod test {
                     &config,
                     SBPFVersion::V3,
                     Box::new(move |region, _, _, _, _| {
-                        // check that the argument passed to MemoryRegion::new_readonly is then passed to the
+                        // check that the argument passed to MemoryRegion::new is then passed to the
                         // callback
                         assert_eq!(region.access_violation_handler_payload, Some(42));
                         c.borrow_mut().extend_from_slice(&original1);

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -88,7 +88,7 @@ unsafe impl<T: VmExposable> HostMemoryObject for *const T {
     }
 }
 
-unsafe impl<T: VmExposable> HostMemoryObject for *mut T {
+unsafe impl<T: VmExposableMut> HostMemoryObject for *mut T {
     const WRITABLE: bool = true;
     fn host_address(self) -> usize {
         self.expose_provenance()
@@ -118,7 +118,7 @@ unsafe impl<T: VmExposableMut> HostMemoryObject for *mut [T] {
     }
 }
 
-unsafe impl<T: VmExposableMut, const N: usize> HostMemoryObject for *const [T; N] {
+unsafe impl<T: VmExposable, const N: usize> HostMemoryObject for *const [T; N] {
     const WRITABLE: bool = false;
     fn host_address(self) -> usize {
         self.expose_provenance()
@@ -128,7 +128,7 @@ unsafe impl<T: VmExposableMut, const N: usize> HostMemoryObject for *const [T; N
     }
 }
 
-unsafe impl<T: VmExposable, const N: usize> HostMemoryObject for *mut [T; N] {
+unsafe impl<T: VmExposableMut, const N: usize> HostMemoryObject for *mut [T; N] {
     const WRITABLE: bool = true;
     fn host_address(self) -> usize {
         self.expose_provenance()

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -59,13 +59,10 @@ pub struct MemoryRegion {
 }
 
 impl MemoryRegion {
-    fn new_from_pointer(
-        pointer: u64,
-        len: u64,
-        vm_addr: u64,
-        vm_gap_size: u64,
-        writable: bool,
-    ) -> Self {
+    /// Create a VM memory region with host `address` pointing to a `len` bytes of data.
+    ///
+    /// This region will be made available in the guest at `vm_addr`.
+    fn new(address: usize, len: usize, vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
         let mut vm_gap_shift = (std::mem::size_of::<u64>() as u8)
             .saturating_mul(8)
             .saturating_sub(1);
@@ -74,48 +71,62 @@ impl MemoryRegion {
             debug_assert_eq!(Some(vm_gap_size), 1_u64.checked_shl(vm_gap_shift as u32));
         };
         MemoryRegion {
-            host_addr: pointer,
+            host_addr: address as u64,
             vm_addr,
-            len,
+            len: len as u64,
             vm_gap_shift,
             writable,
             access_violation_handler_payload: None,
         }
     }
 
-    /// Used to create a region for an object other than a slice
-    pub fn new_readonly_gapless_from_pointer(pointer: u64, vm_addr: u64, len: u64) -> Self {
-        Self::new_from_pointer(pointer, len, vm_addr, 0, false)
+    /// Used to create a memory region for a host object.
+    pub fn new_readonly_object<T>(object: *const T, vm_addr: u64) -> Self {
+        Self::new(
+            object.expose_provenance() as _,
+            std::mem::size_of::<T>() as _,
+            vm_addr,
+            0,
+            false,
+        )
     }
 
-    fn new(slice: &[u8], vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
-        Self::new_from_pointer(
-            slice.as_ptr() as u64,
-            slice.len() as u64,
+    /// Only to be used in tests and benches
+    pub fn new_for_testing(slice: &[u8], vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
+        Self::new(
+            slice.as_ptr().expose_provenance(),
+            slice.len(),
             vm_addr,
             vm_gap_size,
             writable,
         )
     }
 
-    /// Only to be used in tests and benches
-    pub fn new_for_testing(slice: &[u8], vm_addr: u64, vm_gap_size: u64, writable: bool) -> Self {
-        Self::new(slice, vm_addr, vm_gap_size, writable)
-    }
-
-    /// Creates a new readonly MemoryRegion from a slice
-    pub fn new_readonly(slice: &[u8], vm_addr: u64) -> Self {
-        Self::new(slice, vm_addr, 0, false)
+    /// Creates a new readonly MemoryRegion from a slice.
+    ///
+    /// The backing data must remain allocated for the duration of the returned `MemoryRegion`.
+    pub fn new_readonly(slice: *const [u8], vm_addr: u64) -> Self {
+        Self::new(slice.expose_provenance(), slice.len(), vm_addr, 0, false)
     }
 
     /// Creates a new writable MemoryRegion from a mutable slice
-    pub fn new_writable(slice: &mut [u8], vm_addr: u64) -> Self {
-        Self::new(&*slice, vm_addr, 0, true)
+    ///
+    /// The backing data must remain allocated for the duration of the returned `MemoryRegion`.
+    pub fn new_writable(slice: *mut [u8], vm_addr: u64) -> Self {
+        Self::new(slice.expose_provenance(), slice.len(), vm_addr, 0, true)
     }
 
     /// Creates a new writable gapped MemoryRegion from a mutable slice
-    pub fn new_writable_gapped(slice: &mut [u8], vm_addr: u64, vm_gap_size: u64) -> Self {
-        Self::new(&*slice, vm_addr, vm_gap_size, true)
+    ///
+    /// The backing data must remain allocated for the duration of the returned `MemoryRegion`.
+    pub fn new_writable_gapped(slice: *mut [u8], vm_addr: u64, vm_gap_size: u64) -> Self {
+        Self::new(
+            slice.expose_provenance(),
+            slice.len(),
+            vm_addr,
+            vm_gap_size,
+            true,
+        )
     }
 
     /// Returns the vm address space covered by this MemoryRegion
@@ -841,7 +852,11 @@ mod test {
             let mut m = MemoryMapping::new(
                 vec![
                     MemoryRegion::new_readonly(&[0; 8], ebpf::MM_REGION_SIZE),
-                    MemoryRegion::new_writable_gapped(&mut mem1, ebpf::MM_REGION_SIZE * 2, 2),
+                    MemoryRegion::new_writable_gapped(
+                        &raw mut mem1[..],
+                        ebpf::MM_REGION_SIZE * 2,
+                        2,
+                    ),
                 ],
                 &config,
                 SBPFVersion::V3,
@@ -984,8 +999,8 @@ mod test {
         let mem2 = vec![0xDD; 4];
         let m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + 4),
+                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
+                MemoryRegion::new_readonly(&raw const mem2[..], ebpf::MM_REGION_SIZE + 4),
             ],
             &config,
             SBPFVersion::V3,
@@ -1022,8 +1037,8 @@ mod test {
         let mem2 = vec![0xDD; 4];
         let m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE * 2),
+                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
+                MemoryRegion::new_readonly(&raw const mem2[..], ebpf::MM_REGION_SIZE * 2),
             ],
             &config,
             SBPFVersion::V4,
@@ -1086,8 +1101,11 @@ mod test {
         let mut mem2 = vec![0xff];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_writable(&mut mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
+                MemoryRegion::new_writable(
+                    &raw mut mem2[..],
+                    ebpf::MM_REGION_SIZE + mem1.len() as u64,
+                ),
             ],
             &config,
             SBPFVersion::V3,
@@ -1112,7 +1130,10 @@ mod test {
 
         let mut mem1 = vec![0xFF];
         let mut m = MemoryMapping::new(
-            vec![MemoryRegion::new_writable(&mut mem1, ebpf::MM_REGION_SIZE)],
+            vec![MemoryRegion::new_writable(
+                &raw mut mem1[..],
+                ebpf::MM_REGION_SIZE,
+            )],
             &config,
             SBPFVersion::V3,
         )
@@ -1128,8 +1149,8 @@ mod test {
         let mut mem2 = vec![0xDD; 4];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_writable(&mut mem2, ebpf::MM_REGION_SIZE + 4),
+                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
+                MemoryRegion::new_writable(&raw mut mem2[..], ebpf::MM_REGION_SIZE + 4),
             ],
             &config,
             SBPFVersion::V3,
@@ -1150,7 +1171,10 @@ mod test {
 
         let mem1 = vec![0xff];
         let mut m = MemoryMapping::new(
-            vec![MemoryRegion::new_readonly(&mem1, ebpf::MM_REGION_SIZE)],
+            vec![MemoryRegion::new_readonly(
+                &raw const mem1[..],
+                ebpf::MM_REGION_SIZE,
+            )],
             &config,
             SBPFVersion::V3,
         )
@@ -1164,8 +1188,8 @@ mod test {
         let mem2 = vec![0xDD; 4];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_readonly(&mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + 4),
+                MemoryRegion::new_readonly(&raw const mem1[..], ebpf::MM_REGION_SIZE),
+                MemoryRegion::new_readonly(&raw const mem2[..], ebpf::MM_REGION_SIZE + 4),
             ],
             &config,
             SBPFVersion::V3,
@@ -1185,8 +1209,11 @@ mod test {
         let mem2 = vec![0xff, 0xff];
         let mut m = MemoryMapping::new(
             vec![
-                MemoryRegion::new_writable(&mut mem1, ebpf::MM_REGION_SIZE),
-                MemoryRegion::new_readonly(&mem2, ebpf::MM_REGION_SIZE + mem1.len() as u64),
+                MemoryRegion::new_writable(&raw mut mem1[..], ebpf::MM_REGION_SIZE),
+                MemoryRegion::new_readonly(
+                    &raw const mem2[..],
+                    ebpf::MM_REGION_SIZE + mem1.len() as u64,
+                ),
             ],
             &config,
             SBPFVersion::V3,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -298,9 +298,7 @@ pub enum RuntimeEnvironmentSlot {
 ///     0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // add64 r0, 0
 ///     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00  // exit
 /// ];
-/// let mem = &mut [
-///     0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd
-/// ];
+/// let mut mem: [u8; _] = [0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd];
 ///
 /// let loader = std::sync::Arc::new(BuiltinProgram::new_mock());
 /// let function_registry = FunctionRegistry::default();
@@ -315,12 +313,9 @@ pub enum RuntimeEnvironmentSlot {
 ///
 /// let regions: Vec<MemoryRegion> = vec![
 ///     executable.get_ro_region(),
-///     MemoryRegion::new_writable(
-///         stack.as_slice_mut(),
-///         ebpf::MM_STACK_START,
-///     ),
-///     MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
-///     MemoryRegion::new_writable(mem, ebpf::MM_INPUT_START),
+///     MemoryRegion::new(&raw const stack, ebpf::MM_STACK_START),
+///     MemoryRegion::new(&raw mut heap, ebpf::MM_HEAP_START),
+///     MemoryRegion::new(&raw mut mem, ebpf::MM_INPUT_START),
 /// ];
 ///
 /// context_object.memory_mapping = MemoryMapping::new(regions, executable.get_config(), sbpf_version).unwrap();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -313,12 +313,14 @@ pub enum RuntimeEnvironmentSlot {
 ///
 /// let regions: Vec<MemoryRegion> = vec![
 ///     executable.get_ro_region(),
-///     MemoryRegion::new(&raw const stack, ebpf::MM_STACK_START),
-///     MemoryRegion::new(&raw mut heap, ebpf::MM_HEAP_START),
+///     MemoryRegion::new(&mut stack, ebpf::MM_STACK_START),
+///     MemoryRegion::new(&mut heap, ebpf::MM_HEAP_START),
 ///     MemoryRegion::new(&raw mut mem, ebpf::MM_INPUT_START),
 /// ];
-///
-/// context_object.memory_mapping = MemoryMapping::new(regions, executable.get_config(), sbpf_version).unwrap();
+///;
+/// context_object.memory_mapping = unsafe {
+///     MemoryMapping::new(regions, executable.get_config(), sbpf_version).unwrap()
+/// };
 ///
 /// let mut vm = EbpfVm::new(loader, sbpf_version, &mut context_object, stack_len);
 ///
@@ -615,7 +617,7 @@ mod tests {
         let version = SBPFVersion::V4;
         let config = Config::default();
         let mut context_object =
-            DummyContextObject(MemoryMapping::new(vec![], &config, version).unwrap());
+            unsafe { DummyContextObject(MemoryMapping::new(vec![], &config, version).unwrap()) };
         let env = super::EbpfVm::new(
             Arc::new(BuiltinProgram::new_mock()),
             version,

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -232,8 +232,8 @@ pub fn create_memory_mapping<'a, C: ContextObject>(
     let sbpf_version = executable.get_sbpf_version();
     let regions: Vec<MemoryRegion> = vec![
         executable.get_ro_region(),
-        MemoryRegion::new_writable_gapped(
-            stack.as_slice_mut(),
+        MemoryRegion::new_gapped(
+            &raw mut *stack.as_slice_mut(),
             ebpf::MM_STACK_START,
             if sbpf_version.stack_frame_gaps() && config.enable_stack_frame_gaps {
                 config.stack_frame_size as u64
@@ -241,7 +241,7 @@ pub fn create_memory_mapping<'a, C: ContextObject>(
                 0
             },
         ),
-        MemoryRegion::new_writable(heap.as_slice_mut(), ebpf::MM_HEAP_START),
+        MemoryRegion::new(&raw mut *heap.as_slice_mut(), ebpf::MM_HEAP_START),
     ]
     .into_iter()
     .chain(additional_regions.into_iter())
@@ -308,8 +308,8 @@ macro_rules! test_interpreter_and_jit {
         let original_budget = context_object.remaining;
         $executable.verify::<RequisiteVerifier>().unwrap();
         let (instruction_count_interpreter, result_interpreter, interpreter_final_pc, _trace_interpreter) = {
-            let mut mem = $mem;
-            let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
+            let mut mem: [u8; _] = $mem;
+            let mem_region = MemoryRegion::new(&raw mut mem, ebpf::MM_INPUT_START);
             let mut call_frames = vec![
                 solana_sbpf::vm::CallFrame::default();
                 $executable.get_config().max_call_depth
@@ -341,8 +341,8 @@ macro_rules! test_interpreter_and_jit {
             context_object.remaining = original_budget;
             #[allow(unused_mut)]
             let compilation_result = $executable.jit_compile();
-            let mut mem = $mem;
-            let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
+            let mut mem: [u8; _] = $mem;
+            let mem_region = MemoryRegion::new(&raw mut mem, ebpf::MM_INPUT_START);
             create_vm!(
                 vm,
                 &$executable,

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -35,8 +35,10 @@ impl Default for TestContextObject {
     fn default() -> Self {
         Self {
             remaining: 0,
-            memory_mapping: MemoryMapping::new(vec![], &Config::default(), SBPFVersion::Reserved)
-                .unwrap(),
+            memory_mapping: unsafe {
+                MemoryMapping::new(vec![], &Config::default(), SBPFVersion::Reserved)
+            }
+            .unwrap(),
         }
     }
 }
@@ -247,7 +249,7 @@ pub fn create_memory_mapping<'a, C: ContextObject>(
     .chain(additional_regions.into_iter())
     .collect();
 
-    Ok(
+    Ok(unsafe {
         if let Some(access_violation_handler) = access_violation_handler {
             MemoryMapping::new_with_access_violation_handler(
                 regions,
@@ -257,8 +259,8 @@ pub fn create_memory_mapping<'a, C: ContextObject>(
             )?
         } else {
             MemoryMapping::new(regions, config, sbpf_version)?
-        },
-    )
+        }
+    })
 }
 
 #[macro_export]

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -366,7 +366,8 @@ fn test_owned_ro_region_no_initial_gap() {
     ];
     let ro_section = ElfExecutable::parse_ro_sections(&config, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping =
+        unsafe { MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0) }.unwrap();
     let owned_section = match &ro_section {
         Section::Owned(_offset, data) => data.as_slice(),
         _ => panic!(),
@@ -415,7 +416,8 @@ fn test_owned_ro_region_initial_gap_mappable() {
     // V2 requires optimize_rodata=true
     let ro_section = ElfExecutable::parse_ro_sections(&config, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping =
+        unsafe { MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap() };
     let owned_section = match &ro_section {
         Section::Owned(_offset, data) => data.as_slice(),
         _ => panic!(),
@@ -466,7 +468,8 @@ fn test_owned_ro_region_initial_gap_map_error() {
         _ => panic!(),
     };
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping =
+        unsafe { MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap() };
 
     // s1 starts at sh_addr=10 so [MM_REGION_SIZE..MM_REGION_SIZE + 10] is not mappable
 
@@ -564,7 +567,8 @@ fn test_borrowed_ro_region_no_initial_gap() {
     ];
     let ro_section = ElfExecutable::parse_ro_sections(&config, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping =
+        unsafe { MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap() };
 
     // s1 starts at sh_offset=0 so [0..s2.sh_offset + s2.sh_size]
     // is the valid ro memory area
@@ -599,7 +603,8 @@ fn test_borrowed_ro_region_initial_gap() {
     ];
     let ro_section = ElfExecutable::parse_ro_sections(&config, sections, &elf_bytes).unwrap();
     let ro_region = get_ro_region(&ro_section, &elf_bytes);
-    let memory_mapping = MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap();
+    let memory_mapping =
+        unsafe { MemoryMapping::new(vec![ro_region], &config, SBPFVersion::V0).unwrap() };
 
     // s2 starts at sh_addr=10 so [0..10] is not mappable
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3116,7 +3116,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     let (instruction_count_interpreter, trace_interpreter, result_interpreter) = {
         let mut mem = vec![0u8; mem_size];
         let mut context_object = TestContextObject::new(max_instruction_count);
-        let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
+        let mem_region = MemoryRegion::new_writable(&raw mut mem[..], ebpf::MM_INPUT_START);
         let mut call_frames = vec![CallFrame::default(); Config::default().max_call_depth];
         create_vm!(
             vm,
@@ -3141,7 +3141,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     };
     let mut mem = vec![0u8; mem_size];
     let mut context_object = TestContextObject::new(max_instruction_count);
-    let mem_region = MemoryRegion::new_writable(&mut mem, ebpf::MM_INPUT_START);
+    let mem_region = MemoryRegion::new_writable(&raw mut mem[..], ebpf::MM_INPUT_START);
     create_vm!(
         vm,
         &executable,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3116,7 +3116,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     let (instruction_count_interpreter, trace_interpreter, result_interpreter) = {
         let mut mem = vec![0u8; mem_size];
         let mut context_object = TestContextObject::new(max_instruction_count);
-        let mem_region = MemoryRegion::new_writable(&raw mut mem[..], ebpf::MM_INPUT_START);
+        let mem_region = MemoryRegion::new(&raw mut mem[..], ebpf::MM_INPUT_START);
         let mut call_frames = vec![CallFrame::default(); Config::default().max_call_depth];
         create_vm!(
             vm,
@@ -3141,7 +3141,7 @@ fn execute_generated_program(prog: &[u8]) -> bool {
     };
     let mut mem = vec![0u8; mem_size];
     let mut context_object = TestContextObject::new(max_instruction_count);
-    let mem_region = MemoryRegion::new_writable(&raw mut mem[..], ebpf::MM_INPUT_START);
+    let mem_region = MemoryRegion::new(&raw mut mem[..], ebpf::MM_INPUT_START);
     create_vm!(
         vm,
         &executable,


### PR DESCRIPTION
This is a request-for-comments pretty much. Based on my review of #170 I figured I'd prototype what I thought might be less iffy an API for creating memory regions.

Main concerns addressed here are the way references are used to create an aliasing address of the provided slice. Using a pointer here avoids both the concerns about aliasing *and* somewhat more clearly indicates to the caller that something funky is going on with lifetimes and that they cannot e.g. just drop the backing vector after they create the `MemoryRegion`.

