### PR TITLE
Uninitialize the memory mapping

### DIFF
--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -593,20 +593,18 @@ impl MemoryMapping {
         }
     }
 
-    /// Returns the `MemoryRegion`s as mutable
-    pub fn get_regions_mut(&mut self) -> Option<&mut [MemoryRegion]> {
-        if self.initialized {
-            // Returning the regions as mutable after initialization might break the initialization
-            // constraints.
-            return None;
-        }
+    /// Returns the `MemoryRegion`s as mutable, and uninitialize the mapping.
+    /// Modifying the regions might break the initialization constraints, so this function
+    /// uninitializes the mapping.
+    pub fn get_regions_mut(&mut self) -> &mut [MemoryRegion] {
+        self.initialized = false;
 
         let regions = match &mut self.ty {
             MemoryMappingType::Aligned(inner) => inner.regions.as_mut_slice(),
             MemoryMappingType::Unaligned(inner) => &mut inner.regions,
         };
 
-        Some(regions)
+        regions
     }
 
     /// Replaces the `MemoryRegion` at the given index

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -593,9 +593,11 @@ impl MemoryMapping {
         }
     }
 
-    /// Returns the `MemoryRegion`s as mutable, and uninitialize the mapping.
+    /// Returns the [`MemoryRegion`]s as mutable.
+    ///
     /// Modifying the regions might break the initialization constraints, so this function
-    /// uninitializes the mapping.
+    /// uninitializes the mapping. The memory mappings must be initialized
+    /// again with [`Self::initialize`] before further use.
     pub fn get_regions_mut(&mut self) -> &mut [MemoryRegion] {
         self.initialized = false;
 


### PR DESCRIPTION
**Problem**

I noticed that only returning the regions when the mapping was initialized does not integrate so well with ABIv2, since we must update the ro_data region, the stack and heap for every instruction.

I reckoned it was better to uninitialize the mapping when returning the mutable slice, and call `fn initialize` again afterwards to ensure the constraints are correctly met.

**Solution**

`get_regions_mut` now returns the reference to the slice, and uninitialize the mapping.