### PR TITLE
register-tracing: record icount_remaining per traced instruction

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -17,6 +17,7 @@ use crate::{
     elf::Executable,
     error::{EbpfError, ProgramResult},
     program::BuiltinFunction,
+    static_analysis::RegisterTraceEntry,
     vm::{CallFrame, Config, ContextObject, EbpfVm},
 };
 
@@ -198,7 +199,17 @@ impl<'a, 'b, 'c, C: ContextObject> Interpreter<'a, 'b, 'c, C> {
         let src = insn.src as usize;
 
         if config.enable_register_tracing {
-            self.vm.register_trace.push(self.reg);
+            let cus_remaining = if config.enable_instruction_meter {
+                self.vm
+                    .previous_instruction_meter
+                    .saturating_sub(self.vm.due_insn_count)
+            } else {
+                0
+            };
+            self.vm.register_trace.push(RegisterTraceEntry {
+                registers: self.reg,
+                cus_remaining,
+            });
         }
 
         match insn.opc {

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -199,7 +199,7 @@ impl<'a, 'b, 'c, C: ContextObject> Interpreter<'a, 'b, 'c, C> {
         let src = insn.src as usize;
 
         if config.enable_register_tracing {
-            let cus_remaining = if config.enable_instruction_meter {
+            let icount_remaining = if config.enable_instruction_meter {
                 self.vm
                     .previous_instruction_meter
                     .saturating_sub(self.vm.due_insn_count)
@@ -208,7 +208,7 @@ impl<'a, 'b, 'c, C: ContextObject> Interpreter<'a, 'b, 'c, C> {
             };
             self.vm.register_trace.push(RegisterTraceEntry {
                 registers: self.reg,
-                cus_remaining,
+                icount_remaining,
             });
         }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1408,7 +1408,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         // Routine for instruction tracing
         if self.config.enable_register_tracing {
             self.set_anchor(ANCHOR_TRACE);
-            // Reserve slot for CUs remaining (entry[12]) at the highest address; push 0 so it
+            // Reserve slot for icount_remaining (entry[12]) at the highest address; push 0 so it
             // reads as 0 when the instruction meter is disabled (we overwrite it below if not).
             self.emit_ins(X86Instruction::push_immediate(OperandSize::S64, 0));
             // Save registers on stack: entry[11] = pc (REGISTER_SCRATCH), entry[0..11] = REGISTER_MAP.
@@ -1418,7 +1418,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             }
             self.emit_ins(X86Instruction::mov(OperandSize::S64, RSP, REGISTER_MAP[0]));
             if self.config.enable_instruction_meter {
-                // Compute CUs remaining = REGISTER_INSTRUCTION_METER - saved_pc - 1 and store to entry[12].
+                // Compute icount_remaining = REGISTER_INSTRUCTION_METER - saved_pc - 1 and store to entry[12].
                 // REGISTER_INSTRUCTION_METER holds the live counter, and saved_pc lives at [REGISTER_MAP[0] + 8 * REGISTER_MAP.len()].
                 // The -1 matches the interpreter (due_insn_count is incremented before the trace is pushed).
                 self.emit_ins(X86Instruction::mov(OperandSize::S64, REGISTER_INSTRUCTION_METER, REGISTER_SCRATCH)); // REGISTER_SCRATCH = instruction_meter

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1438,7 +1438,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
             self.emit_ins(X86Instruction::pop(REGISTER_MAP[0]));
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, 8 * (REGISTER_MAP.len() - 1) as i64, None)); // RSP += 8 * (REGISTER_MAP.len() - 1);
             self.emit_ins(X86Instruction::pop(REGISTER_SCRATCH));
-            self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, 8, None)); // RSP += 8; (discard CUs slot)
+            self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, 8, None)); // RSP += 8; (discard icount_remaining slot)
             self.emit_ins(X86Instruction::return_near());
         }
 

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1408,22 +1408,37 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         // Routine for instruction tracing
         if self.config.enable_register_tracing {
             self.set_anchor(ANCHOR_TRACE);
-            // Save registers on stack
+            // Reserve slot for CUs remaining (entry[12]) at the highest address; push 0 so it
+            // reads as 0 when the instruction meter is disabled (we overwrite it below if not).
+            self.emit_ins(X86Instruction::push_immediate(OperandSize::S64, 0));
+            // Save registers on stack: entry[11] = pc (REGISTER_SCRATCH), entry[0..11] = REGISTER_MAP.
             self.emit_ins(X86Instruction::push(REGISTER_SCRATCH, None));
             for reg in REGISTER_MAP.iter().rev() {
                 self.emit_ins(X86Instruction::push(*reg, None));
             }
             self.emit_ins(X86Instruction::mov(OperandSize::S64, RSP, REGISTER_MAP[0]));
-            self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, - 8 * 3, None)); // RSP -= 8 * 3;
+            if self.config.enable_instruction_meter {
+                // Compute CUs remaining = REGISTER_INSTRUCTION_METER - saved_pc - 1 and store to entry[12].
+                // REGISTER_INSTRUCTION_METER holds the live counter, and saved_pc lives at [REGISTER_MAP[0] + 8 * REGISTER_MAP.len()].
+                // The -1 matches the interpreter (due_insn_count is incremented before the trace is pushed).
+                self.emit_ins(X86Instruction::mov(OperandSize::S64, REGISTER_INSTRUCTION_METER, REGISTER_SCRATCH)); // REGISTER_SCRATCH = instruction_meter
+                self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x2B, REGISTER_SCRATCH, REGISTER_MAP[0],
+                    Some(X86IndirectAccess::Offset(8 * (REGISTER_MAP.len() as i32))))); // REGISTER_SCRATCH -= saved_pc
+                self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 5, REGISTER_SCRATCH, 1, None)); // REGISTER_SCRATCH -= 1
+                self.emit_ins(X86Instruction::store(OperandSize::S64, REGISTER_SCRATCH, REGISTER_MAP[0],
+                    X86IndirectAccess::Offset(8 * (REGISTER_MAP.len() as i32 + 1)))); // entry[12] = REGISTER_SCRATCH
+            }
+            self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, - 8 * 2, None)); // RSP -= 8 * 2; (alignment)
             self.emit_rust_call(Value::Constant64(Vec::<crate::static_analysis::RegisterTraceEntry>::push as *const u8 as i64, false), &[
                 Argument { index: 1, value: Value::Register(REGISTER_MAP[0]) }, // registers
                 Argument { index: 0, value: Value::RegisterPlusConstant32(REGISTER_PTR_TO_VM, self.slot_in_vm(RuntimeEnvironmentSlot::RegisterTrace), false) },
             ], None);
             // Pop stack and return
-            self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, 8 * 3, None)); // RSP += 8 * 3;
+            self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, 8 * 2, None)); // RSP += 8 * 2;
             self.emit_ins(X86Instruction::pop(REGISTER_MAP[0]));
             self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, 8 * (REGISTER_MAP.len() - 1) as i64, None)); // RSP += 8 * (REGISTER_MAP.len() - 1);
             self.emit_ins(X86Instruction::pop(REGISTER_SCRATCH));
+            self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 0, RSP, 8, None)); // RSP += 8; (discard CUs slot)
             self.emit_ins(X86Instruction::return_near());
         }
 

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -16,8 +16,17 @@ use std::ptr;
 
 /// Register state recorded after executing one instruction
 ///
-/// The last register is the program counter (aka pc).
-pub type RegisterTraceEntry = [u64; 12];
+/// `registers` holds r0..r10 followed by the program counter. `cus_remaining`
+/// is the instruction-meter budget remaining at the time the entry was
+/// captured, or 0 when the instruction meter is disabled.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RegisterTraceEntry {
+    /// Registers r0..r10 followed by the program counter in slot 11.
+    pub registers: [u64; 12],
+    /// Instruction-meter budget remaining when this entry was captured.
+    pub cus_remaining: u64,
+}
 
 /// Used for topological sort
 #[derive(PartialEq, Eq, Debug)]
@@ -522,15 +531,16 @@ impl<'a> Analysis<'a> {
             pc_to_insn_index[insn.ptr + 1] = index;
         }
         for (index, entry) in register_trace.iter().enumerate() {
-            let pc = entry[11] as usize;
+            let pc = entry.registers[11] as usize;
             let insn = &self.instructions[pc_to_insn_index[pc]];
             writeln!(
                 output,
-                "{:5?} {:016X?} {:5?}: {}",
+                "{:5?} {:016X?} {:5?}: {} (CUs left: {})",
                 index,
-                &entry[0..11],
+                &entry.registers[0..11],
                 pc,
                 self.disassemble_instruction(insn, pc),
+                entry.cus_remaining
             )?;
         }
         Ok(())

--- a/src/static_analysis.rs
+++ b/src/static_analysis.rs
@@ -16,7 +16,7 @@ use std::ptr;
 
 /// Register state recorded after executing one instruction
 ///
-/// `registers` holds r0..r10 followed by the program counter. `cus_remaining`
+/// `registers` holds r0..r10 followed by the program counter. `icount_remaining`
 /// is the instruction-meter budget remaining at the time the entry was
 /// captured, or 0 when the instruction meter is disabled.
 #[repr(C)]
@@ -25,7 +25,9 @@ pub struct RegisterTraceEntry {
     /// Registers r0..r10 followed by the program counter in slot 11.
     pub registers: [u64; 12],
     /// Instruction-meter budget remaining when this entry was captured.
-    pub cus_remaining: u64,
+    ///
+    /// Not a stable interface — may change as the metering logic evolves.
+    pub icount_remaining: u64,
 }
 
 /// Used for topological sort
@@ -535,12 +537,12 @@ impl<'a> Analysis<'a> {
             let insn = &self.instructions[pc_to_insn_index[pc]];
             writeln!(
                 output,
-                "{:5?} {:016X?} {:5?}: {} (CUs left: {})",
+                "{:5?} {:016X?} {:5?}: {} (icount_remaining: {})",
                 index,
                 &entry.registers[0..11],
                 pc,
                 self.disassemble_instruction(insn, pc),
-                entry.cus_remaining
+                entry.icount_remaining
             )?;
         }
         Ok(())

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -216,14 +216,14 @@ pub struct DynamicAnalysis {
 
 impl DynamicAnalysis {
     /// Accumulates a trace
-    pub fn new(register_trace: &[[u64; 12]], analysis: &Analysis) -> Self {
+    pub fn new(register_trace: &[RegisterTraceEntry], analysis: &Analysis) -> Self {
         let mut result = Self {
             edge_counter_max: 0,
             edges: BTreeMap::new(),
         };
         let mut last_basic_block = usize::MAX;
         for traced_instruction in register_trace.iter() {
-            let pc = traced_instruction[11] as usize;
+            let pc = traced_instruction.registers[11] as usize;
             if analysis.cfg_nodes.contains_key(&pc) {
                 let counter = result
                     .edges


### PR DESCRIPTION
The register trace recorded only contains the VM registers - no visibility into instruction consumption at each traced instruction, making it painful to correlate execution steps with budget usage when debugging (take syscalls for example). As there's a pseudo register for the remaining instructions in the debugger, it seems legit to have them collected through the traces hence this PR.

The agave counterpart: https://github.com/anza-xyz/agave/commit/31fa8ee40bbecc54ac9b5b8a1398d8b068188905