### PR TITLE
debugger: SBPFv3 support for PC translation and .text reads

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -184,7 +184,7 @@ fn get_host_ptr<C: ContextObject>(
     // SBPFv3+ separates .text (PF_X, at MM_BYTECODE_START) from rodata
     // (PF_R, at MM_RODATA_START), and only rodata gets a MemoryRegion. Serve
     // text reads from the Executable directly so the debugger can disassemble
-    // code and read constants the linker placed inside the bytecode segment.
+    // code.
     if interpreter
         .executable
         .get_sbpf_version()

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -181,6 +181,22 @@ fn get_host_ptr<C: ContextObject>(
         vm_addr += ebpf::MM_BYTECODE_START;
     }
 
+    // SBPFv3+ separates .text (PF_X, at MM_BYTECODE_START) from rodata
+    // (PF_R, at MM_RODATA_START), and only rodata gets a MemoryRegion. Serve
+    // text reads from the Executable directly so the debugger can disassemble
+    // code and read constants the linker placed inside the bytecode segment.
+    if interpreter
+        .executable
+        .get_sbpf_version()
+        .enable_lower_rodata_vaddr()
+    {
+        let (text_vaddr, text_bytes) = interpreter.executable.get_text_bytes();
+        if vm_addr >= text_vaddr && vm_addr < text_vaddr.saturating_add(text_bytes.len() as u64) {
+            let offset = (vm_addr - text_vaddr) as usize;
+            return Ok(unsafe { text_bytes.as_ptr().add(offset) as *mut u8 });
+        }
+    }
+
     // SAFETY: The creator of EbpfVm must guarantee the pointer is valid.
     unsafe {
         match interpreter.vm.memory_mapping.as_ref().map(

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -345,6 +345,12 @@ impl<C: ContextObject> Executable<C> {
         self.text_section_range.start as u64
     }
 
+    /// Get the text section virtual address (matches what LLDB sees)
+    #[cfg(feature = "debugger")]
+    pub fn get_text_section_vaddr(&self) -> u64 {
+        self.text_section_vaddr
+    }
+
     /// Get the loader built-in program
     pub fn get_loader(&self) -> &Arc<BuiltinProgram<C>> {
         &self.loader

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -132,7 +132,20 @@ impl<'a, 'b, 'c, C: ContextObject> Interpreter<'a, 'b, 'c, C> {
     /// Translate between the virtual machines' pc value and the pc value used by the debugger
     #[cfg(feature = "debugger")]
     pub fn get_dbg_pc(&self) -> u64 {
-        (self.reg[11] * ebpf::INSN_SIZE as u64) + self.executable.get_text_section_offset()
+        // V3+ ELFs place .text at its real vaddr (e.g. 0x1_0000_0000) in the on-disk
+        // sh_addr/p_vaddr, which is also what LLDB uses when it loads the .so.debug.
+        // Pre-V3 ELFs have .text at sh_addr=0 in the file (the runtime adds MM_REGION_SIZE
+        // itself), so reporting a file-offset-style PC happens to line up with LLDB's view.
+        let base = if self
+            .executable
+            .get_sbpf_version()
+            .enable_lower_rodata_vaddr()
+        {
+            self.executable.get_text_section_vaddr()
+        } else {
+            self.executable.get_text_section_offset()
+        };
+        base + self.reg[11] * ebpf::INSN_SIZE as u64
     }
 
     fn push_frame(&mut self, config: &Config) -> bool {


### PR DESCRIPTION
Flagging here two small fixes that make `SBPFv3` binaries debuggable through the gdbstub (https://github.com/anza-xyz/sbpf/pull/176 and https://github.com/anza-xyz/llvm-project/pull/195 are also necessary - the latter trying to fix the problem where stack variables are reported as 0x0 values):

- `get_dbg_pc` reports PCs using the `.text` virtual address for SBPFv3
  (`text_section_vaddr`), keeping the old file-offset formula for
  pre-v3. New `Executable::get_text_section_vaddr()` accessor
  (debugger-feature gated) backs it.
- `get_host_ptr` gains a v3 fallback: requests landing inside the
  bytecode segment are served straight from
  `Executable::get_text_bytes()` instead of going through
  `memory_mapping`.