### PR TITLE
Panic instead of returning `EbpfError::LibcInvocationFailed`

### DIFF
--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -47,7 +47,12 @@ macro_rules! libc_error_guard {
                 let errno = *libc::__errno();
                 #[cfg(target_os = "linux")]
                 let errno = *libc::__errno_location();
-                return Err(EbpfError::LibcInvocationFailed(stringify!($function), args, errno));
+                panic!(
+                    "Libc calling {} {:?} returned error code {}",
+                    stringify!($function),
+                    args,
+                    errno
+                );
             }
         }
     }};
@@ -66,7 +71,12 @@ macro_rules! winapi_error_guard {
         if !winapi_error_guard!(succeeded?, $function, $($arg),*) {
             let args = vec![$(format!("{:?}", $arg)),*];
             let errno = GetLastError();
-            return Err(EbpfError::LibcInvocationFailed(stringify!($function), args, errno as i32));
+            panic!(
+                "Libc calling {} {:?} returned error code {}",
+                stringify!($function),
+                args,
+                errno as i32,
+            );
         }
     }};
 }

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -72,7 +72,7 @@ macro_rules! winapi_error_guard {
             let args = vec![$(format!("{:?}", $arg)),*];
             let errno = GetLastError();
             panic!(
-                "Libc calling {} {:?} returned error code {}",
+                "WinAPI calling {} {:?} returned error code {}",
                 stringify!($function),
                 args,
                 errno as i32,


### PR DESCRIPTION
Closes #178

## Why

When a libc / WinAPI call inside `libc_error_guard!` or `winapi_error_guard!` fails after the 3-attempt retry budget is exhausted, the macros previously returned `Err(EbpfError::LibcInvocationFailed(..))`. Propagating the error far downstream caused secondary issues in unrelated areas before the validator finally diverged, exactly the debugging difficulty raised in the issue.

## What

Panic at the failure site instead. The panic message keeps the function name, formatted arguments, and errno so the original signal isn't lost:

```
Libc calling mmap ["0xdead..", "4096", ...] returned error code 12
```

Both macros (Linux/macOS/BSD via libc and Windows via winapi) get the same treatment.

## Public surface

`EbpfError::LibcInvocationFailed` is left defined to avoid a breaking change to the public enum. After this change it is no longer constructed internally and can be removed in a follow-up if desired.

## Verification

```
cargo build --lib
cargo clippy --lib --tests
cargo test --lib   # 144 passed
cargo fmt --check
```