### PR TITLE
Implement bucketed freelist for jit compilation memory

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -72,35 +72,6 @@ pub enum EbpfError {
     /// Syscall error
     #[error("Syscall error: {0}")]
     SyscallError(Box<dyn Error>),
-    /// JIT allocation error
-    #[error(transparent)]
-    JitAllocationError(#[from] JitAllocationError),
-}
-
-/// Errors associated with JIT allocation
-#[derive(Debug, thiserror::Error)]
-pub enum JitAllocationError {
-    /// Requested allocation size would overflow `usize::MAX`
-    #[error("Requested size {0} would overflow usize::MAX")]
-    SizeOverflow(usize),
-    /// Requested memory exceeds maximum memory pool capacity
-    #[error(
-        "Requested memory exceeds maximum memory pool capacity. Requested: {requested}, Max: {max}"
-    )]
-    InsufficientPoolSize {
-        /// Requested allocation size
-        requested: usize,
-        /// Maximum pool size
-        max: usize,
-    },
-    /// Attempted to free an allocation that does not match the expected size
-    #[error("Free size mismatch. Expected: {expected}, Actual: {actual}")]
-    FreeSizeMismatch {
-        /// Expected allocation size
-        expected: usize,
-        /// Actual allocation size
-        actual: usize,
-    },
 }
 
 /// Same as `Result` but provides a stable memory layout

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,35 @@ pub enum EbpfError {
     /// Syscall error
     #[error("Syscall error: {0}")]
     SyscallError(Box<dyn Error>),
+    /// JIT allocation error
+    #[error(transparent)]
+    JitAllocationError(#[from] JitAllocationError),
+}
+
+/// Errors associated with JIT allocation
+#[derive(Debug, thiserror::Error)]
+pub enum JitAllocationError {
+    /// Requested allocation size would overflow `usize::MAX`
+    #[error("Requested size {0} would overflow usize::MAX")]
+    SizeOverflow(usize),
+    /// Requested memory exceeds maximum memory pool capacity
+    #[error(
+        "Requested memory exceeds maximum memory pool capacity. Requested: {requested}, Max: {max}"
+    )]
+    InsufficientPoolSize {
+        /// Requested allocation size
+        requested: usize,
+        /// Maximum pool size
+        max: usize,
+    },
+    /// Attempted to free an allocation that does not match the expected size
+    #[error("Free size mismatch. Expected: {expected}, Actual: {actual}")]
+    FreeSizeMismatch {
+        /// Expected allocation size
+        expected: usize,
+        /// Actual allocation size
+        actual: usize,
+    },
 }
 
 /// Same as `Result` but provides a stable memory layout

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -60,10 +60,11 @@ pub struct JitProgram {
     allocation_size: usize,
     /// Byte offset in the text_section for each BPF instruction
     pc_section: &'static mut [u32],
-    /// The x86 machinecode
+    /// The x86 machinecode.
+    ///
+    /// Before sealing this is the full code capacity; after sealing
+    /// this is the emitted code.
     text_section: &'static mut [u8],
-    /// The length of emitted host machine code in bytes.
-    machine_code_length: usize,
 }
 
 impl JitProgram {
@@ -89,7 +90,6 @@ impl JitProgram {
                     raw.add(pc_loc_table_size),
                     over_allocated_code_size,
                 ),
-                machine_code_length: 0,
             })
         }
     }
@@ -109,7 +109,6 @@ impl JitProgram {
                 0xcc,
                 code_size - text_section_usage,
             );
-            self.machine_code_length = text_section_usage;
             protect_pages(
                 self.pc_section.as_mut_ptr().cast::<u8>(),
                 pc_loc_table_size,
@@ -120,6 +119,8 @@ impl JitProgram {
                 code_size,
                 PagePermissions::ReadExecute,
             )?;
+            self.text_section =
+                std::slice::from_raw_parts_mut(self.text_section.as_mut_ptr(), text_section_usage);
         }
         Ok(())
     }
@@ -185,7 +186,7 @@ impl JitProgram {
 
     /// The length of the host machinecode in bytes
     pub fn machine_code_length(&self) -> usize {
-        self.machine_code_length
+        self.text_section.len()
     }
 
     /// The total pooled allocation size retained by the compiled program.

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -101,13 +101,13 @@ impl JitProgram {
         let raw = self.pc_section.as_ptr() as *mut u8;
         let pc_loc_table_size =
             round_to_page_size(std::mem::size_of_val(self.pc_section), self.page_size);
-        let over_allocated_code_size = round_to_page_size(self.text_section.len(), self.page_size);
+        let code_size = round_to_page_size(text_section_usage, self.page_size);
         unsafe {
             // Fill with debugger traps
             std::ptr::write_bytes(
                 raw.add(pc_loc_table_size).add(text_section_usage),
                 0xcc,
-                over_allocated_code_size - text_section_usage,
+                code_size - text_section_usage,
             );
             self.machine_code_length = text_section_usage;
             protect_pages(
@@ -117,7 +117,7 @@ impl JitProgram {
             )?;
             protect_pages(
                 self.text_section.as_mut_ptr(),
-                over_allocated_code_size,
+                code_size,
                 PagePermissions::ReadExecute,
             )?;
         }

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -75,15 +75,16 @@ impl JitProgram {
             allocate_pages_pooled(pc_loc_table_size + over_allocated_code_size);
 
         unsafe {
+            let pc_section = std::slice::from_raw_parts_mut(raw.cast::<u32>(), pc);
             // pc_section relies on zero-initialization to distinguish unfilled
             // forward-jump targets from filled backward-jump targets in
             // relative_to_target_pc. The pool may hand back recycled memory, so
             // zero just the pc_section bytes here.
-            std::ptr::write_bytes(raw, 0, pc * std::mem::size_of::<u32>());
+            pc_section.fill(0);
             Ok(Self {
                 page_size,
                 allocation_size,
-                pc_section: std::slice::from_raw_parts_mut(raw.cast::<u32>(), pc),
+                pc_section,
                 text_section: std::slice::from_raw_parts_mut(
                     raw.add(pc_loc_table_size),
                     over_allocated_code_size,

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -72,7 +72,7 @@ impl JitProgram {
         let pc_loc_table_size = round_to_page_size(pc * std::mem::size_of::<u32>(), page_size);
         let over_allocated_code_size = round_to_page_size(code_size, page_size);
         let (raw, allocation_size) =
-            allocate_pages_pooled(pc_loc_table_size + over_allocated_code_size)?;
+            allocate_pages_pooled(pc_loc_table_size + over_allocated_code_size);
 
         unsafe {
             // pc_section relies on zero-initialization to distinguish unfilled
@@ -196,7 +196,7 @@ impl JitProgram {
 impl Drop for JitProgram {
     fn drop(&mut self) {
         unsafe {
-            let _ = free_pages_pooled(
+            free_pages_pooled(
                 self.pc_section.as_mut_ptr().cast::<u8>(),
                 self.allocation_size,
             );

--- a/src/jit.rs
+++ b/src/jit.rs
@@ -30,7 +30,8 @@ use crate::{
     elf::Executable,
     error::{EbpfError, ProgramResult},
     memory_management::{
-        allocate_pages, free_pages, get_system_page_size, protect_pages, round_to_page_size,
+        allocate_pages_pooled, free_pages_pooled, get_system_page_size, protect_pages,
+        round_to_page_size, PagePermissions,
     },
     memory_region::MemoryMapping,
     program::BuiltinFunction,
@@ -55,10 +56,14 @@ pub const MAX_START_PADDING_LENGTH: usize = 256;
 pub struct JitProgram {
     /// OS page size in bytes and the alignment of the sections
     page_size: usize,
+    /// Full pooled allocation size backing the pc and text sections.
+    allocation_size: usize,
     /// Byte offset in the text_section for each BPF instruction
     pc_section: &'static mut [u32],
     /// The x86 machinecode
     text_section: &'static mut [u8],
+    /// The length of emitted host machine code in bytes.
+    machine_code_length: usize,
 }
 
 impl JitProgram {
@@ -66,15 +71,24 @@ impl JitProgram {
         let page_size = get_system_page_size();
         let pc_loc_table_size = round_to_page_size(pc * std::mem::size_of::<u32>(), page_size);
         let over_allocated_code_size = round_to_page_size(code_size, page_size);
+        let (raw, allocation_size) =
+            allocate_pages_pooled(pc_loc_table_size + over_allocated_code_size)?;
+
         unsafe {
-            let raw = allocate_pages(pc_loc_table_size + over_allocated_code_size)?;
+            // pc_section relies on zero-initialization to distinguish unfilled
+            // forward-jump targets from filled backward-jump targets in
+            // relative_to_target_pc. The pool may hand back recycled memory, so
+            // zero just the pc_section bytes here.
+            std::ptr::write_bytes(raw, 0, pc * std::mem::size_of::<u32>());
             Ok(Self {
                 page_size,
+                allocation_size,
                 pc_section: std::slice::from_raw_parts_mut(raw.cast::<u32>(), pc),
                 text_section: std::slice::from_raw_parts_mut(
                     raw.add(pc_loc_table_size),
                     over_allocated_code_size,
                 ),
+                machine_code_length: 0,
             })
         }
     }
@@ -87,28 +101,24 @@ impl JitProgram {
         let pc_loc_table_size =
             round_to_page_size(std::mem::size_of_val(self.pc_section), self.page_size);
         let over_allocated_code_size = round_to_page_size(self.text_section.len(), self.page_size);
-        let code_size = round_to_page_size(text_section_usage, self.page_size);
         unsafe {
             // Fill with debugger traps
             std::ptr::write_bytes(
                 raw.add(pc_loc_table_size).add(text_section_usage),
                 0xcc,
-                code_size - text_section_usage,
+                over_allocated_code_size - text_section_usage,
             );
-            if over_allocated_code_size > code_size {
-                free_pages(
-                    raw.add(pc_loc_table_size).add(code_size),
-                    over_allocated_code_size - code_size,
-                )?;
-            }
-            self.text_section =
-                std::slice::from_raw_parts_mut(raw.add(pc_loc_table_size), text_section_usage);
+            self.machine_code_length = text_section_usage;
             protect_pages(
                 self.pc_section.as_mut_ptr().cast::<u8>(),
                 pc_loc_table_size,
-                false,
+                PagePermissions::Read,
             )?;
-            protect_pages(self.text_section.as_mut_ptr(), code_size, true)?;
+            protect_pages(
+                self.text_section.as_mut_ptr(),
+                over_allocated_code_size,
+                PagePermissions::ReadExecute,
+            )?;
         }
         Ok(())
     }
@@ -174,30 +184,22 @@ impl JitProgram {
 
     /// The length of the host machinecode in bytes
     pub fn machine_code_length(&self) -> usize {
-        self.text_section.len()
+        self.machine_code_length
     }
 
-    /// The total memory used in bytes rounded up to page boundaries
+    /// The total pooled allocation size retained by the compiled program.
     pub fn mem_size(&self) -> usize {
-        let pc_loc_table_size =
-            round_to_page_size(std::mem::size_of_val(self.pc_section), self.page_size);
-        let code_size = round_to_page_size(self.text_section.len(), self.page_size);
-        pc_loc_table_size + code_size
+        self.allocation_size
     }
 }
 
 impl Drop for JitProgram {
     fn drop(&mut self) {
-        let pc_loc_table_size =
-            round_to_page_size(std::mem::size_of_val(self.pc_section), self.page_size);
-        let code_size = round_to_page_size(self.text_section.len(), self.page_size);
-        if pc_loc_table_size + code_size > 0 {
-            unsafe {
-                let _ = free_pages(
-                    self.pc_section.as_ptr() as *mut u8,
-                    pc_loc_table_size + code_size,
-                );
-            }
+        unsafe {
+            let _ = free_pages_pooled(
+                self.pc_section.as_mut_ptr().cast::<u8>(),
+                self.allocation_size,
+            );
         }
     }
 }

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -110,7 +110,7 @@ impl Drop for FreeList {
 /// Minimum allocation size for a bucket.
 const BUCKET_MIN: usize = 1024 * 128; // 128 KiB
 /// Maximum allocation size for a bucket.
-const BUCKET_MAX: usize = 1024 * 1024 * 1024; // 1 GiB
+const BUCKET_MAX: usize = 1024 * 1024 * 256; // 256 MiB
 /// Number of buckets in the free list.
 const BUCKET_COUNT: usize =
     (BUCKET_MAX.trailing_zeros() - BUCKET_MIN.trailing_zeros()) as usize + 1;

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -163,8 +163,6 @@ impl BucketedFreeList {
 
     /// Round up the requested size to the nearest power-of-two
     /// and determine the corresponding bucket index.
-    ///
-    /// Errors if the allocation would exceed the maximum bucket size, [`BUCKET_MAX`].
     #[inline]
     fn bucket_idx(&self, size: usize) -> usize {
         let bucket_size = size

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -164,18 +164,16 @@ impl BucketedFreeList {
     /// Round up the requested size to the nearest power-of-two
     /// and determine the corresponding bucket index.
     #[inline]
-    fn bucket_idx(&self, size: usize) -> usize {
-        let bucket_size = size
-            .max(BUCKET_MIN)
-            .checked_next_power_of_two()
-            .expect("allocation would exceed usize::MAX");
-        (bucket_size / BUCKET_MIN).trailing_zeros() as usize
+    #[expect(clippy::arithmetic_side_effects)]
+    fn bucket_idx(size: usize) -> usize {
+        let bucket_bits = usize::BITS - (size.max(BUCKET_MIN) - 1).leading_zeros();
+        bucket_bits as usize - const { BUCKET_MIN.trailing_zeros() as usize }
     }
 
     /// Allocate memory of at least the given size, returning a pointer to the allocation
     /// and the actual size allocated.
     fn alloc(&self, size: usize) -> (*mut u8, usize) {
-        self.buckets[self.bucket_idx(size)].alloc()
+        self.buckets[Self::bucket_idx(size)].alloc()
     }
 
     /// Free the given allocation, returning it to the pool.
@@ -188,7 +186,7 @@ impl BucketedFreeList {
     ///   `free`; subsequent `alloc` calls may hand the same memory to another
     ///   owner.
     unsafe fn free(&self, ptr: *mut u8, size: usize) {
-        unsafe { self.buckets[self.bucket_idx(size)].free(ptr, size) }
+        unsafe { self.buckets[Self::bucket_idx(size)].free(ptr, size) }
     }
 }
 

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -8,7 +8,7 @@
 
 use std::sync::{LazyLock, Mutex};
 
-use crate::error::{EbpfError, JitAllocationError};
+use crate::error::EbpfError;
 
 #[cfg(not(target_os = "windows"))]
 extern crate libc;
@@ -60,14 +60,14 @@ impl FreeList {
     /// Returned memory has read-write permissions and may contain arbitrary
     /// bytes left over from a previous owner; the caller should not assume
     /// any particular contents.
-    fn alloc(&self) -> Result<(*mut u8, usize), EbpfError> {
+    fn alloc(&self) -> (*mut u8, usize) {
         let ptr = { self.mem.lock().unwrap_or_else(|e| e.into_inner()).pop() };
         let ptr = match ptr {
             Some(ptr) => ptr,
-            None => unsafe { allocate_pages(self.size) }?,
+            None => unsafe { allocate_pages(self.size) }.expect("allocation failed"),
         };
 
-        Ok((ptr, self.size))
+        (ptr, self.size)
     }
 
     /// Free the given allocation, returning it to the pool.
@@ -80,19 +80,15 @@ impl FreeList {
     /// - The caller must not retain any reference into the block after calling
     ///   `free`; subsequent `alloc` calls may hand the same memory to another
     ///   owner.
-    unsafe fn free(&self, ptr: *mut u8, size: usize) -> Result<(), EbpfError> {
+    unsafe fn free(&self, ptr: *mut u8, size: usize) {
         if size != self.size {
-            return Err(JitAllocationError::FreeSizeMismatch {
-                expected: self.size,
-                actual: size,
-            }
-            .into());
+            panic!("free size mismatch: expected {}, got {}", self.size, size);
         }
 
-        unsafe { protect_pages(ptr, self.size, PagePermissions::ReadWrite) }?;
+        unsafe { protect_pages(ptr, self.size, PagePermissions::ReadWrite) }
+            .expect("failed to protect pages");
 
         self.mem.lock().unwrap_or_else(|e| e.into_inner()).push(ptr);
-        Ok(())
     }
 }
 
@@ -158,27 +154,18 @@ impl BucketedFreeList {
     ///
     /// Errors if the allocation would exceed the maximum bucket size, [`BUCKET_MAX`].
     #[inline]
-    fn bucket_idx(&self, size: usize) -> Result<usize, EbpfError> {
+    fn bucket_idx(&self, size: usize) -> usize {
         let bucket_size = size
             .max(BUCKET_MIN)
             .checked_next_power_of_two()
-            .ok_or(JitAllocationError::SizeOverflow(size))?;
-        let idx = (bucket_size / BUCKET_MIN).trailing_zeros() as usize;
-        if idx < self.buckets.len() {
-            Ok(idx)
-        } else {
-            Err(JitAllocationError::InsufficientPoolSize {
-                requested: size,
-                max: BUCKET_MAX,
-            }
-            .into())
-        }
+            .expect("allocation would exceed usize::MAX");
+        (bucket_size / BUCKET_MIN).trailing_zeros() as usize
     }
 
     /// Allocate memory of at least the given size, returning a pointer to the allocation
     /// and the actual size allocated.
-    fn alloc(&self, size: usize) -> Result<(*mut u8, usize), EbpfError> {
-        self.buckets[self.bucket_idx(size)?].alloc()
+    fn alloc(&self, size: usize) -> (*mut u8, usize) {
+        self.buckets[self.bucket_idx(size)].alloc()
     }
 
     /// Free the given allocation, returning it to the pool.
@@ -190,8 +177,8 @@ impl BucketedFreeList {
     /// - The caller must not retain any reference into the block after calling
     ///   `free`; subsequent `alloc` calls may hand the same memory to another
     ///   owner.
-    unsafe fn free(&self, ptr: *mut u8, size: usize) -> Result<(), EbpfError> {
-        unsafe { self.buckets[self.bucket_idx(size)?].free(ptr, size) }
+    unsafe fn free(&self, ptr: *mut u8, size: usize) {
+        unsafe { self.buckets[self.bucket_idx(size)].free(ptr, size) }
     }
 }
 
@@ -199,7 +186,7 @@ static ALLOCATOR: LazyLock<BucketedFreeList> = LazyLock::new(BucketedFreeList::n
 
 /// Allocate memory of at least the given size, returning a pointer to the allocation
 /// and the actual size allocated.
-pub fn allocate_pages_pooled(size: usize) -> Result<(*mut u8, usize), EbpfError> {
+pub fn allocate_pages_pooled(size: usize) -> (*mut u8, usize) {
     ALLOCATOR.alloc(size)
 }
 
@@ -212,7 +199,7 @@ pub fn allocate_pages_pooled(size: usize) -> Result<(*mut u8, usize), EbpfError>
 /// - The caller must not retain any reference into the allocation after calling
 ///   `free`; subsequent `alloc` calls may hand the same memory to another
 ///   owner.
-pub unsafe fn free_pages_pooled(ptr: *mut u8, size: usize) -> Result<(), EbpfError> {
+pub unsafe fn free_pages_pooled(ptr: *mut u8, size: usize) {
     unsafe { ALLOCATOR.free(ptr, size) }
 }
 

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -81,12 +81,24 @@ impl FreeList {
     ///   `free`; subsequent `alloc` calls may hand the same memory to another
     ///   owner.
     unsafe fn free(&self, ptr: *mut u8, size: usize) {
+        /// The threshold for discarding physical backing from returned memory.
+        ///
+        /// Allocations at or above 128 MiB are uncommon, so drop their
+        /// resident pages when they are returned to the pool.
+        const MADV_DONTNEED_THRESHOLD: usize = 1024 * 1024 * 128; // 128 MiB
+
         if size != self.size {
             panic!("free size mismatch: expected {}, got {}", self.size, size);
         }
 
         unsafe { protect_pages(ptr, self.size, PagePermissions::ReadWrite) }
             .expect("failed to protect pages");
+
+        if self.size >= MADV_DONTNEED_THRESHOLD {
+            if let Err(e) = unsafe { madvise(ptr, self.size, Advice::DontNeed) } {
+                log::error!("FreeList: unable to advise returned allocation: {e}");
+            }
+        }
 
         self.mem.lock().unwrap_or_else(|e| e.into_inner()).push(ptr);
     }
@@ -345,5 +357,37 @@ pub unsafe fn protect_pages(
             ptr_old,
         );
     }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+pub enum Advice {
+    DontNeed,
+}
+
+pub unsafe fn madvise(raw: *mut u8, size_in_bytes: usize, advice: Advice) -> Result<(), EbpfError> {
+    #[cfg(not(target_os = "windows"))]
+    {
+        let advice = match advice {
+            Advice::DontNeed => libc::MADV_DONTNEED,
+        };
+        libc_error_guard!(madvise, raw.cast::<c_void>(), size_in_bytes, advice);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let mut ptr = raw.cast::<c_void>();
+        let advice = match advice {
+            Advice::DontNeed => winnt::MEM_RESET,
+        };
+        winapi_error_guard!(
+            VirtualAlloc,
+            &mut ptr,
+            size_in_bytes,
+            advice,
+            winnt::PAGE_READWRITE,
+        );
+    }
+
     Ok(())
 }

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -6,7 +6,9 @@
 
 #![cfg_attr(target_os = "windows", allow(dead_code))]
 
-use crate::error::EbpfError;
+use std::sync::{LazyLock, Mutex};
+
+use crate::error::{EbpfError, JitAllocationError};
 
 #[cfg(not(target_os = "windows"))]
 extern crate libc;
@@ -24,6 +26,195 @@ use winapi::{
         winnt,
     },
 };
+
+/// A free list for managing memory allocations of a fixed size.
+struct FreeList {
+    /// Pool of free blocks awaiting reuse.
+    mem: Mutex<Vec<*mut u8>>,
+    /// The size of each memory block.
+    size: usize,
+}
+
+// Safety: FreeList only stores mmap allocation base addresses. The pointed-to
+// memory is not accessed through FreeList without holding the FreeList
+// mutex, and ownership of each allocation is transferred into/out of the pool.
+unsafe impl Sync for FreeList {}
+unsafe impl Send for FreeList {}
+
+impl FreeList {
+    /// Create a new free list with the specified size.
+    ///
+    /// This does not allocate any memory blocks; they are allocated lazily as needed.
+    fn new(size: usize) -> Self {
+        Self {
+            mem: Mutex::new(Vec::new()),
+            size,
+        }
+    }
+
+    /// Allocate a memory block of the configured size.
+    ///
+    /// If a free block is available, it is reused; otherwise, a new block is allocated.
+    ///
+    /// Returns a pointer to the allocated memory and the size of the allocation.
+    /// Returned memory has read-write permissions and may contain arbitrary
+    /// bytes left over from a previous owner; the caller should not assume
+    /// any particular contents.
+    fn alloc(&self) -> Result<(*mut u8, usize), EbpfError> {
+        let ptr = { self.mem.lock().unwrap_or_else(|e| e.into_inner()).pop() };
+        let ptr = match ptr {
+            Some(ptr) => {
+                unsafe { protect_pages(ptr, self.size, PagePermissions::ReadWrite) }?;
+                ptr
+            }
+            None => unsafe { allocate_pages(self.size) }?,
+        };
+
+        Ok((ptr, self.size))
+    }
+
+    /// Free the given allocation, returning it to the pool.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must have been returned by [`FreeList::alloc`] on this same
+    ///   instance and not already returned to the pool.
+    /// - `size` must equal the size configured at construction.
+    /// - The caller must not retain any reference into the block after calling
+    ///   `free`; subsequent `alloc` calls may hand the same memory to another
+    ///   owner.
+    unsafe fn free(&self, ptr: *mut u8, size: usize) -> Result<(), EbpfError> {
+        if size != self.size {
+            return Err(JitAllocationError::FreeSizeMismatch {
+                expected: self.size,
+                actual: size,
+            }
+            .into());
+        }
+        self.mem.lock().unwrap_or_else(|e| e.into_inner()).push(ptr);
+        Ok(())
+    }
+}
+
+impl Drop for FreeList {
+    fn drop(&mut self) {
+        for ptr in self
+            .mem
+            .get_mut()
+            .unwrap_or_else(|e| e.into_inner())
+            .drain(..)
+        {
+            if let Err(e) = unsafe { free_pages(ptr, self.size) } {
+                log::error!("FreeList: unable to free {e}");
+            }
+        }
+    }
+}
+
+/// Minimum allocation size for a bucket.
+const BUCKET_MIN: usize = 1024 * 128; // 128 KiB
+/// Maximum allocation size for a bucket.
+const BUCKET_MAX: usize = 1024 * 1024 * 1024; // 1 GiB
+/// Number of buckets in the free list.
+const BUCKET_COUNT: usize =
+    (BUCKET_MAX.trailing_zeros() - BUCKET_MIN.trailing_zeros()) as usize + 1;
+
+const _: () = assert!(BUCKET_MIN.is_power_of_two());
+const _: () = assert!(BUCKET_MAX.is_power_of_two());
+const _: () = assert!(BUCKET_MIN <= BUCKET_MAX);
+const _: () = assert!(BUCKET_MAX == BUCKET_MIN * (1 << (BUCKET_COUNT - 1)));
+
+/// A free list that uses a bucketed strategy to manage memory
+/// allocations of varying sizes.
+///
+/// Buckets are organized by power-of-two size, with the smallest
+/// bucket being [`BUCKET_MIN`] and the largest being [`BUCKET_MAX`].
+///
+/// Allocations will be rounded up to the nearest power-of-two size
+/// and stored in the corresponding bucket.
+///
+/// Returned blocks remain cached in the process-global pool and are not
+/// released back to the OS during normal operation. This intentionally trades
+/// higher retained RSS after peak load for fewer mmap/munmap calls during JIT
+/// churn.
+///
+/// This is safe to use in a multi-threaded context -- locks are
+/// sharded per bucket.
+struct BucketedFreeList {
+    buckets: [FreeList; BUCKET_COUNT],
+}
+
+impl BucketedFreeList {
+    /// Construct an empty pool with one bucket per power-of-two size class.
+    #[expect(clippy::arithmetic_side_effects)]
+    fn new() -> Self {
+        Self {
+            buckets: core::array::from_fn(|i| FreeList::new(BUCKET_MIN * (1 << i))),
+        }
+    }
+
+    /// Round up the requested size to the nearest power-of-two
+    /// and determine the corresponding bucket index.
+    ///
+    /// Errors if the allocation would exceed the maximum bucket size, [`BUCKET_MAX`].
+    #[inline]
+    fn bucket_idx(&self, size: usize) -> Result<usize, EbpfError> {
+        let bucket_size = size
+            .max(BUCKET_MIN)
+            .checked_next_power_of_two()
+            .ok_or(JitAllocationError::SizeOverflow(size))?;
+        let idx = (bucket_size / BUCKET_MIN).trailing_zeros() as usize;
+        if idx < self.buckets.len() {
+            Ok(idx)
+        } else {
+            Err(JitAllocationError::InsufficientPoolSize {
+                requested: size,
+                max: BUCKET_MAX,
+            }
+            .into())
+        }
+    }
+
+    /// Allocate memory of at least the given size, returning a pointer to the allocation
+    /// and the actual size allocated.
+    fn alloc(&self, size: usize) -> Result<(*mut u8, usize), EbpfError> {
+        self.buckets[self.bucket_idx(size)?].alloc()
+    }
+
+    /// Free the given allocation, returning it to the pool.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must have been returned by [`BucketedFreeList::alloc`] on this same
+    ///   instance and not already returned to the pool.
+    /// - The caller must not retain any reference into the block after calling
+    ///   `free`; subsequent `alloc` calls may hand the same memory to another
+    ///   owner.
+    unsafe fn free(&self, ptr: *mut u8, size: usize) -> Result<(), EbpfError> {
+        unsafe { self.buckets[self.bucket_idx(size)?].free(ptr, size) }
+    }
+}
+
+static ALLOCATOR: LazyLock<BucketedFreeList> = LazyLock::new(BucketedFreeList::new);
+
+/// Allocate memory of at least the given size, returning a pointer to the allocation
+/// and the actual size allocated.
+pub fn allocate_pages_pooled(size: usize) -> Result<(*mut u8, usize), EbpfError> {
+    ALLOCATOR.alloc(size)
+}
+
+/// Free the given allocation.
+///
+/// # Safety
+///
+/// - The pointer and size must identify a full allocation previously returned by
+///   [`allocate_pages_pooled`] and not already returned to the pool.
+/// - The caller must not retain any reference into the allocation after calling
+///   `free`; subsequent `alloc` calls may hand the same memory to another
+///   owner.
+pub unsafe fn free_pages_pooled(ptr: *mut u8, size: usize) -> Result<(), EbpfError> {
+    unsafe { ALLOCATOR.free(ptr, size) }
+}
 
 #[cfg(not(target_os = "windows"))]
 macro_rules! libc_error_guard {
@@ -129,37 +320,41 @@ pub unsafe fn free_pages(raw: *mut u8, size_in_bytes: usize) -> Result<(), EbpfE
     Ok(())
 }
 
+#[derive(Copy, Clone)]
+pub enum PagePermissions {
+    Read,
+    ReadWrite,
+    ReadExecute,
+}
+
 pub unsafe fn protect_pages(
     raw: *mut u8,
     size_in_bytes: usize,
-    executable_flag: bool,
+    permissions: PagePermissions,
 ) -> Result<(), EbpfError> {
     #[cfg(not(target_os = "windows"))]
     {
-        libc_error_guard!(
-            mprotect,
-            raw.cast::<c_void>(),
-            size_in_bytes,
-            if executable_flag {
-                libc::PROT_EXEC | libc::PROT_READ
-            } else {
-                libc::PROT_READ
-            },
-        );
+        let prot = match permissions {
+            PagePermissions::Read => libc::PROT_READ,
+            PagePermissions::ReadWrite => libc::PROT_READ | libc::PROT_WRITE,
+            PagePermissions::ReadExecute => libc::PROT_READ | libc::PROT_EXEC,
+        };
+        libc_error_guard!(mprotect, raw.cast::<c_void>(), size_in_bytes, prot);
     }
     #[cfg(target_os = "windows")]
     {
         let mut old: minwindef::DWORD = 0;
         let ptr_old: *mut minwindef::DWORD = &mut old;
+        let prot = match permissions {
+            PagePermissions::Read => winnt::PAGE_READONLY,
+            PagePermissions::ReadWrite => winnt::PAGE_READWRITE,
+            PagePermissions::ReadExecute => winnt::PAGE_EXECUTE_READ,
+        };
         winapi_error_guard!(
             VirtualProtect,
             raw.cast::<c_void>(),
             size_in_bytes,
-            if executable_flag {
-                winnt::PAGE_EXECUTE_READ
-            } else {
-                winnt::PAGE_READONLY
-            },
+            prot,
             ptr_old,
         );
     }

--- a/src/memory_management.rs
+++ b/src/memory_management.rs
@@ -63,10 +63,7 @@ impl FreeList {
     fn alloc(&self) -> Result<(*mut u8, usize), EbpfError> {
         let ptr = { self.mem.lock().unwrap_or_else(|e| e.into_inner()).pop() };
         let ptr = match ptr {
-            Some(ptr) => {
-                unsafe { protect_pages(ptr, self.size, PagePermissions::ReadWrite) }?;
-                ptr
-            }
+            Some(ptr) => ptr,
             None => unsafe { allocate_pages(self.size) }?,
         };
 
@@ -91,6 +88,9 @@ impl FreeList {
             }
             .into());
         }
+
+        unsafe { protect_pages(ptr, self.size, PagePermissions::ReadWrite) }?;
+
         self.mem.lock().unwrap_or_else(|e| e.into_inner()).push(ptr);
         Ok(())
     }


### PR DESCRIPTION
### Problem

JIT compilation directly mmaps/munmaps memory for page alignment / permissions reasons. Because this circumvents jemalloc, memory is never recycled; this creates continuous fault churn, resulting in programs sometimes taking upwards of 15ms to compile.

<img width="4082" height="2336" alt="image" src="https://github.com/user-attachments/assets/fb0090c4-f1e9-4b8d-84ca-6a187ec09491" />
Yellow here is almost entirely page faults


<img width="3825" height="1527" alt="image" src="https://github.com/user-attachments/assets/973f0ad5-b89c-4e95-ad15-03d5cca3cbc2" />


### Solution

This PR implements a bucketed free list allocator to back JIT compilation memory. Buckets are organized by power-of-two, 128KiB-1GiB, and lazily allocated as needed. This style of allocator is a good fit due to program cache utilization being steady and predictable, and affords us a very simple and easily maintainable implementation.

Buckets are warmed up on validator start and reach steady state once we start executing transactions. Distribution of utilization remains quite stable across long runs.
<img width="3715" height="825" alt="image" src="https://github.com/user-attachments/assets/04d8a92e-57bf-4c91-8beb-377d641f4b8c" />

Page faults are eliminated during steady state
<img width="3024" height="1004" alt="image" src="https://github.com/user-attachments/assets/3cc09e96-9b0b-4ff3-9835-29f082867d69" />
