### PR TITLE
ci: move attestation to before publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,15 +108,15 @@ jobs:
         cargo doc
         cargo package
       shell: bash
-    - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
-      id: auth
-    - name: Publish
-      run: cargo publish
-      env:
-        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
     - name: Generate SLSA provenance
       uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
       env:
         NODE_OPTIONS: "--max-http-header-size=32768"
       with:
         subject-path: target/package/*.crate
+    - uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe  # v1.0.4
+      id: auth
+    - name: Publish
+      run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary

cargo 1.91 stopped keeping `.crate` tarballs in `target/package/` after `cargo publish`. Our release job ran in the order `package → publish → attest`, so by the time `actions/attest` looked for `target/package/*.crate`, the files were gone and the step would have failed.

Reordered to `package → attest → publish` so the `.crate` files still exist when attest reads them.
