### PR TITLE
ci: update to fuzz-upload-action v2

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches: [main]
 
-permissions:                                                                                                                                                                                                                          
-    contents: read
+permissions:
+  contents: read
 
 jobs:
   upload:
@@ -18,7 +18,7 @@ jobs:
 
       - run: rustup update nightly
       - run: rustup default nightly
-      
+
       - uses: dtolnay/install@d0dc46e85ffd2c174b5ac0489e17f95dae84fa5a # cargo-fuzz
       - run: cargo +nightly fuzz build --no-trace-compares
 
@@ -31,26 +31,22 @@ jobs:
           cp ./tests/elfs/*.so /tmp/elf-parser-corpus/
 
       - name: Upload elf-parser corpus to FuzzCorp
-        uses: asymmetric-research/fuzz-upload-action@1140f6fc0fc9c59aa66f3a705c55c93f260f715b # v1.0.4
+        uses: asymmetric-research/fuzz-upload-action@0e367cafdc501772fd0fd7dc13bfa68d49222256 # v2.0.0
         with:
           upload_type: corpus
           upload_path: /tmp/elf-parser-corpus
           upload_args: --lineage elf-parser --kind seed
         env:
-          FUZZ_API_ORIGIN: ${{ secrets.FUZZ_API_ORIGIN }}
           FUZZ_ORGANIZATION: anza
           FUZZ_PROJECT: sbpf
-          FUZZ_USER: ${{ secrets.FUZZ_USER }}
-          FUZZ_PASSWORD: ${{ secrets.FUZZ_PASSWORD }}
+          FUZZ_API_KEY: ${{ secrets.FUZZ_API_KEY }}
 
       - name: Upload bundle to FuzzCorp
-        uses: asymmetric-research/fuzz-upload-action@1140f6fc0fc9c59aa66f3a705c55c93f260f715b # v1.0.4
+        uses: asymmetric-research/fuzz-upload-action@0e367cafdc501772fd0fd7dc13bfa68d49222256 # v2.0.0
         with:
           upload_type: bundle
           upload_path: ./fuzz/target/bundle
         env:
-          FUZZ_API_ORIGIN: ${{ secrets.FUZZ_API_ORIGIN }}
           FUZZ_ORGANIZATION: anza
           FUZZ_PROJECT: sbpf
-          FUZZ_USER: ${{ secrets.FUZZ_USER }}
-          FUZZ_PASSWORD: ${{ secrets.FUZZ_PASSWORD }}
+          FUZZ_API_KEY: ${{ secrets.FUZZ_API_KEY }}


### PR DESCRIPTION
Update to https://github.com/asymmetric-research/fuzz-upload-action/releases/tag/v2.0.0 which uses API keys instead of username/password and no longer requires `FUZZ_API_ORIGIN` (we're deprecating username/password auth and simplifying the config)

> [!NOTE]
> This assumes that an org-level API key has been generated in the AR dashboard and that the `FUZZ_API_KEY` gh actions secret is set. 