### PR TITLE
add stable discriminator repr to ElfError

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -43,6 +43,7 @@ use shuttle::sync::Arc;
 
 /// Error definitions
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[repr(C, u64)]
 pub enum ElfError {
     /// Failed to parse ELF file
     #[error("Failed to parse ELF file: {0}")]

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -42,8 +42,10 @@ use std::sync::Arc;
 use shuttle::sync::Arc;
 
 /// Error definitions
+// Note: `#[repr(u64)]` is used for `Self::discriminant`, but the actual
+// memory layout of this enum's variants is not depended on by the VM.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
-#[repr(C, u64)]
+#[repr(u64)]
 pub enum ElfError {
     /// Failed to parse ELF file
     #[error("Failed to parse ELF file: {0}")]
@@ -114,6 +116,15 @@ pub enum ElfError {
     /// Invalid program header
     #[error("Invalid ELF program header")]
     InvalidProgramHeader,
+}
+
+impl ElfError {
+    /// Returns the enum discriminant as a `u64`.
+    ///
+    /// This is sound only because of the `#[repr(u64)]` attribute on the enum.
+    pub fn discriminant(&self) -> u64 {
+        unsafe { *std::ptr::addr_of!(*self).cast::<u64>() }
+    }
 }
 
 impl From<ElfParserError> for ElfError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,10 @@ use {
 
 /// Error definitions
 #[derive(Debug, thiserror::Error)]
-#[repr(u64)] // discriminant size, used in emit_exception_kind in JIT
+// Note: `#[repr(u64)]` is used for `Self::discriminant` and
+// `emit_exception_kind` in JIT, but the actual memory layout of this enum's
+// variants is not depended on by the VM.
+#[repr(u64)]
 pub enum EbpfError {
     /// ELF error
     #[error("ELF error: {0}")]
@@ -72,6 +75,15 @@ pub enum EbpfError {
     /// Syscall error
     #[error("Syscall error: {0}")]
     SyscallError(Box<dyn Error>),
+}
+
+impl EbpfError {
+    /// Returns the enum discriminant as a `u64`.
+    ///
+    /// This is sound only because of the `#[repr(u64)]` attribute on the enum.
+    pub fn discriminant(&self) -> u64 {
+        unsafe { *std::ptr::addr_of!(*self).cast::<u64>() }
+    }
 }
 
 /// Same as `Result` but provides a stable memory layout


### PR DESCRIPTION
#### Problem
As per discussion in https://github.com/anza-xyz/agave/pull/12921, we want to be able to get the variants for `ElfError` as integers.

#### Summary of Changes
Add a `repr(u64)`.