### PR TITLE
make access violation error message more informative

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,7 @@ pub enum EbpfError {
     #[error("Invalid memory region at index {0}")]
     InvalidMemoryRegion(usize),
     /// Access violation (general)
-    #[error("Access violation in {3} section at address {1:#x} of size {2:?}")]
+    #[error("Access violation {0} {2} bytes at address {1:#x} (in {3} region)")]
     AccessViolation(AccessType, u64, u64, &'static str),
     /// Access violation (stack specific)
     #[error("Access violation in stack frame {3} at address {1:#x} of size {2:?}")]

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -288,6 +288,15 @@ pub enum AccessType {
     Store,
 }
 
+impl std::fmt::Display for AccessType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Load => "reading",
+            Self::Store => "writing",
+        })
+    }
+}
+
 /// Memory mapping based on eytzinger search.
 pub struct UnalignedMemoryMapping {
     /// Common parts
@@ -827,12 +836,16 @@ impl MemoryMapping {
                 stack_frame,
             ))
         } else {
+            let region = self.find_region(vm_addr);
             let region_name = match vm_addr & (!ebpf::MM_BYTECODE_START.saturating_sub(1)) {
+                _ if region.map(|(_, r)| r.vm_addr_range().contains(&vm_addr)) != Some(true) => {
+                    "unallocated"
+                }
                 ebpf::MM_BYTECODE_START => "program",
                 ebpf::MM_STACK_START => "stack",
                 ebpf::MM_HEAP_START => "heap",
                 ebpf::MM_INPUT_START => "input",
-                _ => "unknown",
+                _ => "allocated",
             };
             ProgramResult::Err(EbpfError::AccessViolation(
                 access_type,
@@ -1693,6 +1706,31 @@ mod test {
         };
 
         m.store(33u8, ebpf::MM_REGION_SIZE).unwrap();
+    }
+
+    #[test]
+    fn test_access_violation_region_identification() {
+        let config = Config::default();
+        let original = [11, 22];
+        let region = 0x10_0000_0000;
+        let mut m = unsafe {
+            MemoryMapping::new(
+                vec![MemoryRegion::new(&raw const original, region)],
+                &config,
+                SBPFVersion::V4,
+            )
+            .unwrap()
+        };
+        let store_err_inbound = m.store(33u8, region).unwrap_err();
+        assert_eq!(
+            store_err_inbound.to_string(),
+            "Access violation writing 1 bytes at address 0x1000000000 (in allocated region)"
+        );
+        let store_err_oob = m.load::<u64>(region + 3).unwrap_err();
+        assert_eq!(
+            store_err_oob.to_string(),
+            "Access violation reading 8 bytes at address 0x1000000003 (in unallocated region)"
+        );
     }
 
     #[test]

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -1095,7 +1095,7 @@ fn test_err_ldxdw_nomem() {
             AccessType::Load,
             0x400000006,
             8,
-            "input"
+            "unallocated"
         )),
     );
 }
@@ -1779,7 +1779,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
             AccessType::Store,
             0x3F000 - 64,
             1,
-            "unknown"
+            "unallocated"
         )),
     );
 
@@ -1935,7 +1935,12 @@ fn test_err_mem_access_out_of_bound() {
         ..Config::default()
     };
     let loader = Arc::new(BuiltinProgram::new_loader(config));
-    for address in [0x2u64, 0x8002u64, 0x80000002u64, 0x8000000000000002u64] {
+    for (address, k) in [
+        (0x2u64, "allocated"),
+        (0x8002u64, "unallocated"),
+        (0x80000002u64, "unallocated"),
+        (0x8000000000000002u64, "unallocated"),
+    ] {
         LittleEndian::write_u32(&mut prog[12..], address as u32);
         LittleEndian::write_u32(&mut prog[20..], (address >> 32) as u32);
         #[allow(unused_mut)]
@@ -1950,12 +1955,7 @@ fn test_err_mem_access_out_of_bound() {
             executable,
             mem,
             TestContextObject::new(3),
-            ProgramResult::Err(EbpfError::AccessViolation(
-                AccessType::Store,
-                address,
-                1,
-                "unknown"
-            )),
+            ProgramResult::Err(EbpfError::AccessViolation(AccessType::Store, address, 1, k)),
         );
     }
 }
@@ -3286,7 +3286,7 @@ fn test_err_fixed_stack_out_of_bound() {
             AccessType::Store,
             0x1FFFFD000,
             1,
-            "program"
+            "unallocated"
         )),
     );
 }


### PR DESCRIPTION
It will now describe the access type and whether the region is known to be allocated or not (rather than always saying "unknown" for anything outside the 4 regions known to the vm.)