### PR TITLE
miri: fix pointer provenance in vm_to_host translation

### DIFF
--- a/src/aligned_memory.rs
+++ b/src/aligned_memory.rs
@@ -289,10 +289,9 @@ impl<const ALIGN: usize> AlignedVec<ALIGN> {
     }
 
     fn empty() -> Self {
+        let layout = Layout::from_size_align(0, ALIGN).expect("invalid layout");
         Self {
-            // Create a dangling pointer
-            // FIXME: Use `Layout::dangling_ptr` once Rust 1.95.0 is released
-            ptr: NonNull::new(ALIGN as *mut u8).expect("alignment may not be zero"),
+            ptr: layout.dangling_ptr(),
             length: 0,
             capacity: 0,
         }

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -171,7 +171,7 @@ impl<'a, 'b, 'c, C: ContextObject> Target for Interpreter<'a, 'b, 'c, C> {
 fn get_host_ptr<C: ContextObject>(
     interpreter: &mut Interpreter<C>,
     mut vm_addr: u64,
-) -> Result<*mut u8, EbpfError> {
+) -> Result<*const u8, EbpfError> {
     if !interpreter
         .executable
         .get_sbpf_version()
@@ -181,16 +181,14 @@ fn get_host_ptr<C: ContextObject>(
         vm_addr += ebpf::MM_BYTECODE_START;
     }
 
-    // SAFETY: The creator of EbpfVm must guarantee the pointer is valid.
     unsafe {
-        match interpreter.vm.memory_mapping.as_ref().map(
+        // SAFETY: The creator of EbpfVm must guarantee the `memory_mapping` pointer is valid.
+        let host_buffer = Result::from(interpreter.vm.memory_mapping.as_ref().map(
             AccessType::Load,
             vm_addr,
             std::mem::size_of::<u8>() as u64,
-        ) {
-            ProgramResult::Ok(host_addr) => Ok(host_addr as *mut u8),
-            ProgramResult::Err(err) => Err(err),
-        }
+        ))?;
+        Ok(host_buffer.ptr().cast())
     }
 }
 

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -177,6 +177,44 @@ impl HostBuffer {
             HostBuffer::Mutable(p) => Self::Immutable(p.cast_const()),
         }
     }
+
+    /// Subslice this host buffer with the provided range.
+    pub fn get(self, range: std::ops::Range<usize>) -> Option<Self> {
+        if range.end > self.len() {
+            return None;
+        }
+        let new_len = range.len();
+        unsafe {
+            // SAFETY:
+            //
+            // Contract from `ptr::add`: If the computed offset is non-zero, then self
+            // must be derived from a pointer to some allocation, and the entire memory
+            // range between self and the result must be in bounds of that allocation.
+            // In particular, this range must not "wrap around" the edge of the address
+            // space.
+            //
+            // Evidence: We take care to ensure to only get here if the `begin_offset`
+            // (and a stronger condition: `begin_offset + len`) would be within `len()`
+            // of the base pointer.
+            //
+            // Contract from `ptr::add`: The offset in bytes, count * size_of::<T>(),
+            // computed on mathematical integers (without "wrapping around"), must fit
+            // in an isize.
+            //
+            // Evidence: Allocation size in Rust, including those of the region backing
+            // memory here specifically, may not exceed `isize::MAX` bytes.
+            Some(match self {
+                HostBuffer::Immutable(p) => HostBuffer::Immutable(std::ptr::slice_from_raw_parts(
+                    p.byte_add(range.start).cast(),
+                    new_len,
+                )),
+                HostBuffer::Mutable(p) => HostBuffer::Mutable(std::ptr::slice_from_raw_parts_mut(
+                    p.byte_add(range.start).cast(),
+                    new_len,
+                )),
+            })
+        }
+    }
 }
 
 unsafe impl HostMemoryObject for HostBuffer {
@@ -306,14 +344,11 @@ impl MemoryRegion {
         }
     }
 
-    /// Convert a virtual machine address into a host address.
-    pub fn vm_to_host(&self, access_type: AccessType, vm_addr: u64, len: u64) -> Option<u64> {
-        let (host_addr, host_len) = match self.host {
-            HostBuffer::Immutable(_) if access_type == AccessType::Store => return None,
-            HostBuffer::Immutable(p) => (p.addr() as u64, p.len() as u64),
-            HostBuffer::Mutable(p) => (p.addr() as u64, p.len() as u64),
-        };
-
+    /// Convert a virtual machine address into a host slice.
+    ///
+    /// The returned slice will have exactly `len` bytes. If the provided `vm_addr` does not
+    /// correlate to a valid subslice of this region, a `None` will be returned.
+    pub(crate) fn vm_to_host_buffer(&self, vm_addr: u64, len: u64) -> Option<HostBuffer> {
         // This can happen if a region starts at an offset from the base region
         // address, eg with rodata regions if config.optimize_rodata = true, see
         // Elf::get_ro_region.
@@ -325,9 +360,7 @@ impl MemoryRegion {
         if self.vm_gap_shift == 63 {
             // fast path for non-gapped regions
             if let Some(end_offset) = begin_offset.checked_add(len) {
-                if end_offset <= host_len {
-                    return Some(host_addr.saturating_add(begin_offset));
-                }
+                return self.host.get(begin_offset as usize..end_offset as usize);
             }
             return None;
         }
@@ -341,8 +374,8 @@ impl MemoryRegion {
         let gapped_offset =
             (begin_offset & gap_mask).checked_shr(1).unwrap_or(0) | (begin_offset & !gap_mask);
         if let Some(end_offset) = gapped_offset.checked_add(len) {
-            if end_offset <= host_len && !is_in_gap {
-                return Some(host_addr.saturating_add(gapped_offset));
+            if !is_in_gap {
+                return self.host.get(gapped_offset as usize..end_offset as usize);
             }
         }
         None
@@ -766,6 +799,18 @@ impl MemoryMapping {
         )
     }
 
+    fn host_buffer_to_address(
+        &self,
+        access_type: AccessType,
+        host_buffer: HostBuffer,
+    ) -> Option<u64> {
+        match host_buffer {
+            HostBuffer::Immutable(_) if access_type == AccessType::Store => None,
+            HostBuffer::Immutable(p) => Some(p.expose_provenance() as u64),
+            HostBuffer::Mutable(p) => Some(p.expose_provenance() as u64),
+        }
+    }
+
     /// Map virtual memory to host memory.
     pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64) -> ProgramResult {
         debug_assert!(self.initialized);
@@ -774,8 +819,10 @@ impl MemoryMapping {
         }
 
         if let Some((_index, region)) = self.find_region(vm_addr) {
-            if let Some(host_addr) = region.vm_to_host(access_type, vm_addr, len) {
-                return ProgramResult::Ok(host_addr);
+            if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
+                if let Some(addr) = self.host_buffer_to_address(access_type, host_buffer) {
+                    return ProgramResult::Ok(addr);
+                }
             }
         }
         self.generate_access_violation(access_type, vm_addr, len)
@@ -798,8 +845,10 @@ impl MemoryMapping {
         }
 
         if let Some((index, region)) = self.find_region(vm_addr) {
-            if let Some(host_addr) = region.vm_to_host(access_type, vm_addr, len) {
-                return ProgramResult::Ok(host_addr);
+            if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
+                if let Some(addr) = self.host_buffer_to_address(access_type, host_buffer) {
+                    return ProgramResult::Ok(addr);
+                }
             }
             let mut region = (*region).clone();
             let max_len = self
@@ -808,11 +857,13 @@ impl MemoryMapping {
                 .map_or(u64::MAX, |next_region| next_region.vm_addr)
                 .saturating_sub(region.vm_addr);
             (self.access_violation_handler)(&mut region, max_len, access_type, vm_addr, len);
-            if let Some(host_addr) = region.vm_to_host(access_type, vm_addr, len) {
-                if let Err(err) = unsafe { self.replace_region(index, region) } {
-                    return ProgramResult::Err(err);
+            if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
+                if let Some(addr) = self.host_buffer_to_address(access_type, host_buffer) {
+                    if let Err(err) = unsafe { self.replace_region(index, region) } {
+                        return ProgramResult::Err(err);
+                    }
+                    return ProgramResult::Ok(addr);
                 }
-                return ProgramResult::Ok(host_addr);
             }
         }
         self.generate_access_violation(access_type, vm_addr, len)
@@ -825,7 +876,8 @@ impl MemoryMapping {
         debug_assert!(self.initialized);
         match self.map_with_access_violation_handler(AccessType::Load, vm_addr, len) {
             ProgramResult::Ok(host_addr) => {
-                ProgramResult::Ok(unsafe { ptr::read_unaligned::<T>(host_addr as *const T) }.into())
+                let ptr = ptr::with_exposed_provenance::<T>(host_addr as usize);
+                ProgramResult::Ok(unsafe { ptr::read_unaligned(ptr) }.into())
             }
             err => err,
         }
@@ -839,7 +891,8 @@ impl MemoryMapping {
         debug_assert!(self.initialized);
         match self.map_with_access_violation_handler(AccessType::Store, vm_addr, len) {
             ProgramResult::Ok(host_addr) => {
-                unsafe { ptr::write_unaligned(host_addr as *mut T, value) };
+                let ptr = ptr::with_exposed_provenance_mut::<T>(host_addr as usize);
+                unsafe { ptr::write_unaligned(ptr, value) };
                 ProgramResult::Ok(host_addr)
             }
             err => err,

--- a/src/memory_region.rs
+++ b/src/memory_region.rs
@@ -3,7 +3,7 @@
 use crate::{
     aligned_memory::Pod,
     ebpf,
-    error::{EbpfError, ProgramResult},
+    error::{EbpfError, ProgramResult, StableResult},
     program::SBPFVersion,
     vm::Config,
 };
@@ -179,6 +179,7 @@ impl HostBuffer {
     }
 
     /// Subslice this host buffer with the provided range.
+    #[inline]
     pub fn get(self, range: std::ops::Range<usize>) -> Option<Self> {
         if range.end > self.len() {
             return None;
@@ -204,15 +205,36 @@ impl HostBuffer {
             // Evidence: Allocation size in Rust, including those of the region backing
             // memory here specifically, may not exceed `isize::MAX` bytes.
             Some(match self {
-                HostBuffer::Immutable(p) => HostBuffer::Immutable(std::ptr::slice_from_raw_parts(
+                HostBuffer::Immutable(p) => HostBuffer::Immutable(ptr::slice_from_raw_parts(
                     p.byte_add(range.start).cast(),
                     new_len,
                 )),
-                HostBuffer::Mutable(p) => HostBuffer::Mutable(std::ptr::slice_from_raw_parts_mut(
+                HostBuffer::Mutable(p) => HostBuffer::Mutable(ptr::slice_from_raw_parts_mut(
                     p.byte_add(range.start).cast(),
                     new_len,
                 )),
             })
+        }
+    }
+
+    /// Pointer to a slice of the host memory.
+    #[inline(always)]
+    pub fn ptr(self) -> *const [u8] {
+        match self {
+            HostBuffer::Immutable(p) => p,
+            HostBuffer::Mutable(p) => p,
+        }
+    }
+
+    /// Mutble pointer to a slice of the host memory.
+    #[inline(always)]
+    pub fn ptr_mut(self) -> *mut [u8] {
+        match self {
+            HostBuffer::Immutable(p) => {
+                debug_assert!(false, "ptr_mut, but buffer is immutable");
+                p.cast_mut()
+            }
+            HostBuffer::Mutable(p) => p,
         }
     }
 }
@@ -348,6 +370,7 @@ impl MemoryRegion {
     ///
     /// The returned slice will have exactly `len` bytes. If the provided `vm_addr` does not
     /// correlate to a valid subslice of this region, a `None` will be returned.
+    #[inline]
     pub(crate) fn vm_to_host_buffer(&self, vm_addr: u64, len: u64) -> Option<HostBuffer> {
         // This can happen if a region starts at an offset from the base region
         // address, eg with rodata regions if config.optimize_rodata = true, see
@@ -799,33 +822,32 @@ impl MemoryMapping {
         )
     }
 
-    fn host_buffer_to_address(
+    /// Map virtual memory to host memory.
+    pub fn map(
         &self,
         access_type: AccessType,
-        host_buffer: HostBuffer,
-    ) -> Option<u64> {
-        match host_buffer {
-            HostBuffer::Immutable(_) if access_type == AccessType::Store => None,
-            HostBuffer::Immutable(p) => Some(p.expose_provenance() as u64),
-            HostBuffer::Mutable(p) => Some(p.expose_provenance() as u64),
-        }
-    }
-
-    /// Map virtual memory to host memory.
-    pub fn map(&self, access_type: AccessType, vm_addr: u64, len: u64) -> ProgramResult {
+        vm_addr: u64,
+        len: u64,
+    ) -> StableResult<HostBuffer, EbpfError> {
         debug_assert!(self.initialized);
         if self.disable_address_translation {
-            return ProgramResult::Ok(vm_addr);
+            // NOTE TRICKY: this pointer most likely did *not* get its provenance exposed in the
+            // Rust-land! This option in general is extremely unsafe and have us constructing
+            // pointers to no man's land. We acknowledge this and don't consider it to be a bug,
+            // given that the option isn't meant to be used for any serious applications of this
+            // crate.
+            let ptr = ptr::with_exposed_provenance_mut(vm_addr as usize);
+            let buffer = HostBuffer::Mutable(ptr::slice_from_raw_parts_mut(ptr, len as usize));
+            return StableResult::Ok(buffer);
         }
-
         if let Some((_index, region)) = self.find_region(vm_addr) {
-            if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
-                if let Some(addr) = self.host_buffer_to_address(access_type, host_buffer) {
-                    return ProgramResult::Ok(addr);
+            if region.host_buffer().is_mutable() || access_type != AccessType::Store {
+                if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
+                    return StableResult::Ok(host_buffer);
                 }
             }
         }
-        self.generate_access_violation(access_type, vm_addr, len)
+        StableResult::Err(self.generate_access_violation(access_type, vm_addr, len))
     }
 
     /// Map virtual memory to host memory and potentially call the [AccessViolationHandler].
@@ -838,16 +860,23 @@ impl MemoryMapping {
         access_type: AccessType,
         vm_addr: u64,
         len: u64,
-    ) -> ProgramResult {
+    ) -> StableResult<HostBuffer, EbpfError> {
         debug_assert!(self.initialized);
         if self.disable_address_translation {
-            return ProgramResult::Ok(vm_addr);
+            // NOTE TRICKY: this pointer most likely did *not* get its provenance exposed in the
+            // Rust-land! This option in general is extremely unsafe and have us constructing
+            // pointers to no man's land. We acknowledge this and don't consider it to be a bug,
+            // given that the option isn't meant to be used for any serious applications of this
+            // crate.
+            let ptr = ptr::with_exposed_provenance_mut(vm_addr as usize);
+            let buffer = HostBuffer::Mutable(ptr::slice_from_raw_parts_mut(ptr, len as usize));
+            return StableResult::Ok(buffer);
         }
 
         if let Some((index, region)) = self.find_region(vm_addr) {
-            if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
-                if let Some(addr) = self.host_buffer_to_address(access_type, host_buffer) {
-                    return ProgramResult::Ok(addr);
+            if region.host_buffer().is_mutable() || access_type != AccessType::Store {
+                if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
+                    return StableResult::Ok(host_buffer);
                 }
             }
             let mut region = (*region).clone();
@@ -857,46 +886,61 @@ impl MemoryMapping {
                 .map_or(u64::MAX, |next_region| next_region.vm_addr)
                 .saturating_sub(region.vm_addr);
             (self.access_violation_handler)(&mut region, max_len, access_type, vm_addr, len);
-            if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
-                if let Some(addr) = self.host_buffer_to_address(access_type, host_buffer) {
+            if region.host_buffer().is_mutable() || access_type != AccessType::Store {
+                if let Some(host_buffer) = region.vm_to_host_buffer(vm_addr, len) {
                     if let Err(err) = unsafe { self.replace_region(index, region) } {
-                        return ProgramResult::Err(err);
+                        return StableResult::Err(err);
                     }
-                    return ProgramResult::Ok(addr);
+                    return StableResult::Ok(host_buffer);
                 }
             }
         }
-        self.generate_access_violation(access_type, vm_addr, len)
+        StableResult::Err(self.generate_access_violation(access_type, vm_addr, len))
     }
 
-    /// Loads `size_of::<T>()` bytes from the given address.
+    /// Loads `size_of::<T>()` bytes at the given guest address.
     pub fn load<T: Pod + Into<u64>>(&mut self, vm_addr: u64) -> ProgramResult {
         let len = mem::size_of::<T>() as u64;
         debug_assert!(len <= mem::size_of::<u64>() as u64);
         debug_assert!(self.initialized);
-        match self.map_with_access_violation_handler(AccessType::Load, vm_addr, len) {
-            ProgramResult::Ok(host_addr) => {
-                let ptr = ptr::with_exposed_provenance::<T>(host_addr as usize);
-                ProgramResult::Ok(unsafe { ptr::read_unaligned(ptr) }.into())
-            }
-            err => err,
-        }
+        let ptr = match self.map_with_access_violation_handler(AccessType::Load, vm_addr, len) {
+            StableResult::Err(e) => return ProgramResult::Err(e),
+            StableResult::Ok(buf) => buf.ptr(),
+        };
+        ProgramResult::Ok(unsafe {
+            // SAFETY:
+            //
+            // Contract from `ptr::read_unaligned`: `src` must be valid for reads.
+            // Evidence: So long as `disable_address_translation` is not `true`, `map_*` only
+            // returns valid, allocated subslices of memory.
+            // Contract from `ptr::read_unaligned`: `src` must point to a properly initialized value
+            // of type T.
+            // Evidence: `T: Pod`.
+            ptr::read_unaligned::<T>(ptr.cast()).into()
+        })
     }
 
-    /// Store `value` at the given address.
-    #[inline]
+    /// Store `value` at the given guest address.
     pub fn store<T: Pod>(&mut self, value: T, vm_addr: u64) -> ProgramResult {
         let len = mem::size_of::<T>() as u64;
         debug_assert!(len <= mem::size_of::<u64>() as u64);
         debug_assert!(self.initialized);
-        match self.map_with_access_violation_handler(AccessType::Store, vm_addr, len) {
-            ProgramResult::Ok(host_addr) => {
-                let ptr = ptr::with_exposed_provenance_mut::<T>(host_addr as usize);
-                unsafe { ptr::write_unaligned(ptr, value) };
-                ProgramResult::Ok(host_addr)
-            }
-            err => err,
-        }
+        let ptr = match self.map_with_access_violation_handler(AccessType::Store, vm_addr, len) {
+            StableResult::Err(e) => return ProgramResult::Err(e),
+            StableResult::Ok(buf) => buf.ptr_mut(),
+        };
+        StableResult::Ok(unsafe {
+            // SAFETY:
+            //
+            // Contract from `ptr::read_unaligned`: `src` must be valid for reads.
+            // Evidence: So long as `disable_address_translation` is not `true`, `map_*` only
+            // returns valid, allocated subslices of memory.
+            // Contract from `ptr::read_unaligned`: `src` must point to a properly initialized value
+            // of type T.
+            // Evidence: `T: Pod`.
+            ptr::write_unaligned::<T>(ptr.cast(), value);
+            0
+        })
     }
 
     /// Returns the `MemoryRegion` which may contain the given address.
@@ -977,7 +1021,7 @@ impl MemoryMapping {
         access_type: AccessType,
         vm_addr: u64,
         len: u64,
-    ) -> ProgramResult {
+    ) -> EbpfError {
         let stack_frame = (vm_addr as i64)
             .saturating_sub(ebpf::MM_STACK_START as i64)
             .checked_div(self.stack_frame_size)
@@ -985,12 +1029,7 @@ impl MemoryMapping {
         if !self.sbpf_version.manual_stack_frame_bump()
             && (-1..self.max_call_depth.saturating_add(1)).contains(&stack_frame)
         {
-            ProgramResult::Err(EbpfError::StackAccessViolation(
-                access_type,
-                vm_addr,
-                len,
-                stack_frame,
-            ))
+            EbpfError::StackAccessViolation(access_type, vm_addr, len, stack_frame)
         } else {
             let region = self.find_region(vm_addr);
             let region_name = match vm_addr & (!ebpf::MM_BYTECODE_START.saturating_sub(1)) {
@@ -1003,12 +1042,7 @@ impl MemoryMapping {
                 ebpf::MM_INPUT_START => "input",
                 _ => "allocated",
             };
-            ProgramResult::Err(EbpfError::AccessViolation(
-                access_type,
-                vm_addr,
-                len,
-                region_name,
-            ))
+            EbpfError::AccessViolation(access_type, vm_addr, len, region_name)
         }
     }
 }
@@ -1247,13 +1281,19 @@ mod test {
         };
 
         assert_eq!(
-            m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1).unwrap(),
-            mem1.as_ptr() as u64
+            m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1)
+                .unwrap()
+                .ptr()
+                .addr(),
+            mem1.as_ptr().addr()
         );
 
         assert_eq!(
-            m.map(AccessType::Store, ebpf::MM_REGION_SIZE, 1).unwrap(),
-            mem1.as_ptr() as u64
+            m.map(AccessType::Store, ebpf::MM_REGION_SIZE, 1)
+                .unwrap()
+                .ptr()
+                .addr(),
+            mem1.as_ptr().addr()
         );
 
         assert_error!(
@@ -1267,8 +1307,10 @@ mod test {
                 ebpf::MM_REGION_SIZE + mem1.len() as u64,
                 1,
             )
-            .unwrap(),
-            mem2.as_ptr() as u64
+            .unwrap()
+            .ptr()
+            .addr(),
+            mem2.as_ptr().addr()
         );
 
         assert_eq!(
@@ -1277,8 +1319,10 @@ mod test {
                 ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len()) as u64,
                 1,
             )
-            .unwrap(),
-            mem3.as_ptr() as u64
+            .unwrap()
+            .ptr()
+            .addr(),
+            mem3.as_ptr().addr()
         );
 
         assert_eq!(
@@ -1287,8 +1331,10 @@ mod test {
                 ebpf::MM_REGION_SIZE + (mem1.len() + mem2.len() + mem3.len()) as u64,
                 1,
             )
-            .unwrap(),
-            mem4.as_ptr() as u64
+            .unwrap()
+            .ptr()
+            .addr(),
+            mem4.as_ptr().addr()
         );
 
         assert_error!(
@@ -1560,8 +1606,11 @@ mod test {
         };
 
         assert_eq!(
-            m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1).unwrap(),
-            mem1.as_ptr() as u64
+            m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1)
+                .unwrap()
+                .ptr()
+                .addr(),
+            mem1.as_ptr().addr()
         );
 
         assert_eq!(
@@ -1570,8 +1619,10 @@ mod test {
                 ebpf::MM_REGION_SIZE + mem1.len() as u64,
                 1,
             )
-            .unwrap(),
-            mem2.as_ptr() as u64
+            .unwrap()
+            .ptr()
+            .addr(),
+            mem2.as_ptr().addr()
         );
 
         assert_error!(
@@ -1619,8 +1670,10 @@ mod test {
                 ebpf::MM_REGION_SIZE + mem1.len() as u64,
                 1,
             )
-            .unwrap(),
-            mem3.as_ptr() as u64
+            .unwrap()
+            .ptr()
+            .addr(),
+            mem3.as_ptr().addr()
         );
     }
 
@@ -1647,8 +1700,10 @@ mod test {
 
         assert_eq!(
             m.map(AccessType::Load, ebpf::MM_REGION_SIZE * 2, 1)
-                .unwrap(),
-            mem2.as_ptr() as u64
+                .unwrap()
+                .ptr()
+                .addr(),
+            mem2.as_ptr().addr()
         );
 
         // index > regions.len()
@@ -1694,8 +1749,10 @@ mod test {
 
         assert_eq!(
             m.map(AccessType::Load, ebpf::MM_REGION_SIZE * 2, 1)
-                .unwrap(),
-            mem3.as_ptr() as u64
+                .unwrap()
+                .ptr()
+                .addr(),
+            mem3.as_ptr().addr()
         );
     }
 
@@ -1728,13 +1785,17 @@ mod test {
 
             assert_eq!(
                 m.map_with_access_violation_handler(AccessType::Load, ebpf::MM_REGION_SIZE, 1)
-                    .unwrap(),
-                original.as_ptr() as u64
+                    .unwrap()
+                    .ptr()
+                    .addr(),
+                original.as_ptr().addr()
             );
             assert_eq!(
                 m.map_with_access_violation_handler(AccessType::Store, ebpf::MM_REGION_SIZE, 1)
-                    .unwrap(),
-                copied.borrow().as_ptr() as u64
+                    .unwrap()
+                    .ptr()
+                    .addr(),
+                copied.borrow().as_ptr().addr()
             );
         }
     }
@@ -1767,8 +1828,11 @@ mod test {
             };
 
             assert_eq!(
-                m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1).unwrap(),
-                original.as_ptr() as u64
+                m.map(AccessType::Load, ebpf::MM_REGION_SIZE, 1)
+                    .unwrap()
+                    .ptr()
+                    .addr(),
+                original.as_ptr().addr()
             );
 
             assert_eq!(m.load::<u8>(ebpf::MM_REGION_SIZE).unwrap(), 11);

--- a/test_utils/src/syscalls.rs
+++ b/test_utils/src/syscalls.rs
@@ -22,8 +22,8 @@
 //! respect this convention.
 
 use crate::TestContextObject;
-use solana_sbpf::{declare_builtin_function, error::EbpfError, memory_region::AccessType};
-use std::{slice::from_raw_parts, str::from_utf8};
+use solana_sbpf::{declare_builtin_function, memory_region::AccessType};
+use std::str::from_utf8;
 
 declare_builtin_function!(
     /// Prints its **last three** arguments to standard output. The **first two** arguments are
@@ -90,12 +90,9 @@ declare_builtin_function!(
         if len == 0 {
             return Ok(0);
         }
-        let host_addr: Result<u64, EbpfError> =
-            context_object.memory_mapping.map(AccessType::Store, vm_addr, len).into();
-        let host_addr = host_addr?;
-        for i in 0..len {
-            unsafe {
-                let p = (host_addr + i) as *mut u8;
+        let buf = Result::from(context_object.memory_mapping.map(AccessType::Store, vm_addr, len))?;
+        unsafe {
+            for p in buf.ptr_mut().as_mut_unchecked() {
                 *p ^= 0b101010;
             }
         }
@@ -118,20 +115,19 @@ declare_builtin_function!(
         if arg1 == 0 || arg2 == 0 {
             return Ok(u64::MAX);
         }
-        let a: Result<u64, EbpfError> =
-            context_object.memory_mapping.map(AccessType::Load, arg1, 1).into();
-        let mut a = a?;
-        let b: Result<u64, EbpfError> =
-            context_object.memory_mapping.map(AccessType::Load, arg2, 1).into();
-        let mut b = b?;
+        // Length of 1 here is circumventing soundness checks map does, but for a test its probably
+        // fine.
+        let mut a = Result::from(context_object.memory_mapping.map(AccessType::Load, arg1, 1))?
+            .ptr()
+            .cast::<u8>();
+        let mut b = Result::from(context_object.memory_mapping.map(AccessType::Load, arg2, 1))?
+            .ptr()
+            .cast::<u8>();
         unsafe {
-            let mut a_val = *(a as *const u8);
-            let mut b_val = *(b as *const u8);
+            let (mut a_val, mut b_val) = (*a, *b);
             while a_val == b_val && a_val != 0 && b_val != 0 {
-                a += 1;
-                b += 1;
-                a_val = *(a as *const u8);
-                b_val = *(b as *const u8);
+                (a, b) = (a.add(1), b.add(1));
+                (a_val, b_val) = (*a, *b);
             }
             if a_val >= b_val {
                 Ok((a_val - b_val) as u64)
@@ -156,11 +152,10 @@ declare_builtin_function!(
         if len == 0 {
             return Ok(0);
         }
-        let host_addr: Result<u64, EbpfError> =
-            context_object.memory_mapping.map(AccessType::Load, vm_addr, len).into();
-        let host_addr = host_addr?;
+        let host_buffer =
+            Result::from(context_object.memory_mapping.map(AccessType::Load, vm_addr, len))?;
         unsafe {
-            let c_buf = from_raw_parts(host_addr as *const u8, len as usize);
+            let c_buf = host_buffer.ptr().as_ref_unchecked();
             let len = c_buf.iter().position(|c| *c == 0).unwrap_or(len as usize);
             let message = from_utf8(&c_buf[0..len]).unwrap_or("Invalid UTF-8 String");
             println!("log: {message}");

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -381,8 +381,10 @@ fn test_owned_ro_region_no_initial_gap() {
                 ebpf::MM_REGION_SIZE,
                 s3.sh_addr + s3.sh_size
             )
-            .unwrap(),
-        owned_section.as_ptr() as u64,
+            .unwrap()
+            .ptr()
+            .addr(),
+        owned_section.as_ptr().addr(),
     );
 
     // one byte past the ro section is not mappable
@@ -433,8 +435,10 @@ fn test_owned_ro_region_initial_gap_mappable() {
                 ebpf::MM_REGION_SIZE,
                 s3.sh_addr + s3.sh_size
             )
-            .unwrap(),
-        owned_section.as_ptr() as u64,
+            .unwrap()
+            .ptr()
+            .addr(),
+        owned_section.as_ptr().addr(),
     );
 
     // one byte past the ro section is not mappable
@@ -491,8 +495,10 @@ fn test_owned_ro_region_initial_gap_map_error() {
                 ebpf::MM_REGION_SIZE + s1.sh_addr,
                 s3.sh_addr + s3.sh_size - s1.sh_addr
             )
-            .unwrap(),
-        owned_section.as_ptr() as u64,
+            .unwrap()
+            .ptr()
+            .addr(),
+        owned_section.as_ptr().addr(),
     );
 
     // one byte past the ro section is not mappable
@@ -579,8 +585,10 @@ fn test_borrowed_ro_region_no_initial_gap() {
                 ebpf::MM_REGION_SIZE + s1.sh_offset,
                 s2.sh_offset + s2.sh_size
             )
-            .unwrap(),
-        elf_bytes.as_ptr() as u64,
+            .unwrap()
+            .ptr()
+            .addr(),
+        elf_bytes.as_ptr().addr(),
     );
 
     // one byte past the ro section is not mappable
@@ -626,8 +634,10 @@ fn test_borrowed_ro_region_initial_gap() {
                 ebpf::MM_REGION_SIZE + s2.sh_offset,
                 s3.sh_offset + s3.sh_size - s2.sh_offset
             )
-            .unwrap(),
-        elf_bytes[s2.sh_offset as usize..].as_ptr() as u64,
+            .unwrap()
+            .ptr()
+            .addr(),
+        elf_bytes[s2.sh_offset as usize..].as_ptr().addr(),
     );
 
     // one byte past the ro section is not mappable


### PR DESCRIPTION
After a miri-related advisory against the old `solana-rbpf`, I figured I would run it for sbpf as well just to see how it fares. Mostly clean, except for an attempt to read/write through a pointer without provenance (because `vm_to_host` mapping failed to expose it properly.)

This refactors the relevant parts of sbpf to correctly establish pointer provenance.

The `dangling_ptr()` change raises MSRV to 1.95, but that should be fine given that agave is already on 1.96.