### PR TITLE
fix benchmarks

### DIFF
--- a/benches/memory_mapping.rs
+++ b/benches/memory_mapping.rs
@@ -16,6 +16,7 @@ use solana_sbpf::{
     program::SBPFVersion,
     vm::Config,
 };
+use std::hint;
 use test::Bencher;
 
 fn generate_memory_regions(
@@ -323,15 +324,31 @@ fn do_bench_mapping_operation(bencher: &mut Bencher, op: MemoryOperation) {
     .unwrap();
 
     match op {
-        MemoryOperation::Map => bencher.iter(|| {
-            let _ = memory_mapping.map(AccessType::Load, vm_addr, 8).unwrap();
-        }),
-        MemoryOperation::Load => bencher.iter(|| {
-            let _ = memory_mapping.load::<u64>(vm_addr).unwrap();
-        }),
-        MemoryOperation::Store(val) => bencher.iter(|| {
-            let _ = memory_mapping.store(val, vm_addr).unwrap();
-        }),
+        MemoryOperation::Map => {
+            let f: fn(_, _, _, _) -> _ = hint::black_box(MemoryMapping::map);
+            bencher.iter(|| {
+                f(
+                    &memory_mapping,
+                    AccessType::Load,
+                    hint::black_box(vm_addr),
+                    8,
+                )
+            })
+        }
+        MemoryOperation::Load => {
+            let f: for<'a> fn(&'a mut _, _) -> _ = hint::black_box(MemoryMapping::load::<u64>);
+            bencher.iter(move || f(&mut memory_mapping, hint::black_box(vm_addr)))
+        }
+        MemoryOperation::Store(val) => {
+            let f: for<'a> fn(&'a mut _, _, _) -> _ = hint::black_box(MemoryMapping::store);
+            bencher.iter(move || {
+                f(
+                    &mut memory_mapping,
+                    hint::black_box(val),
+                    hint::black_box(vm_addr),
+                )
+            })
+        }
     }
 }
 


### PR DESCRIPTION
Previously these benchmarks were inlining the scrutinee and doing absolutely nothing.

I chose to also produce a function pointer out of the tested functions as such a function pointer call is exactly what we use in the VM.

Numbers which actually make some sense:

```
test bench_mapping_8_byte_load    ... bench:   5.54 ns/iter (+/- 0.14)
test bench_mapping_8_byte_map     ... bench:   5.34 ns/iter (+/- 0.03)
test bench_mapping_8_byte_store   ... bench:   5.74 ns/iter (+/- 0.06)
```