### PR TITLE
test: ensure (im)mutability of memory regions, test input equivalence

### DIFF
--- a/src/disassembler.rs
+++ b/src/disassembler.rs
@@ -110,6 +110,7 @@ fn jmp_reg_str(name: &str, insn: &ebpf::Insn, cfg_nodes: &BTreeMap<usize, CfgNod
 
 /// Disassemble an eBPF instruction
 #[rustfmt::skip]
+#[allow(clippy::needless_late_init)] // FIXME: convert to expect on rustc >= 1.98.0
 pub fn disassemble_instruction<C: ContextObject>(
     insn: &ebpf::Insn,
     pc: usize,
@@ -260,7 +261,7 @@ pub fn disassemble_instruction<C: ContextObject>(
         ebpf::JSLT32_REG  if sbpf_version.enable_jmp32() => { name = "jslt32"; desc = jmp_reg_str(name, insn, cfg_nodes); },
         ebpf::JSLE32_IMM  if sbpf_version.enable_jmp32() => { name = "jsle32"; desc = jmp_imm_str(name, insn, cfg_nodes); },
         ebpf::JSLE32_REG  if sbpf_version.enable_jmp32() => { name = "jsle32"; desc = jmp_reg_str(name, insn, cfg_nodes); },
-        
+
         // BPF_JMP64 class
         ebpf::JA         => {
             name = "ja";

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -150,7 +150,7 @@ pub const TCP_SACK_ASM: &str = "
     mov r0, 0x1
     exit";
 
-pub const TCP_SACK_BIN: [u8; 360] = [
+pub static TCP_SACK_BIN: [u8; 360] = [
     0x47, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
     0x71, 0x12, 0x0c, 0x00, 0x00, 0x00, 0x00, 0x00, //
     0x71, 0x13, 0x0d, 0x00, 0x00, 0x00, 0x00, 0x00, //
@@ -198,7 +198,7 @@ pub const TCP_SACK_BIN: [u8; 360] = [
     0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
 ];
 
-pub const TCP_SACK_MATCH: [u8; 78] = [
+pub static TCP_SACK_MATCH: [u8; 78] = [
     0x00, 0x26, 0x62, 0x2f, 0x47, 0x87, 0x00, 0x1d, //
     0x60, 0xb3, 0x01, 0x84, 0x08, 0x00, 0x45, 0x00, //
     0x00, 0x40, 0xa8, 0xde, 0x40, 0x00, 0x40, 0x06, //
@@ -211,7 +211,7 @@ pub const TCP_SACK_MATCH: [u8; 78] = [
     0xca, 0x28, 0xa3, 0xc4, 0xcf, 0xd0, //
 ];
 
-pub const TCP_SACK_NOMATCH: [u8; 66] = [
+pub static TCP_SACK_NOMATCH: [u8; 66] = [
     0x00, 0x26, 0x62, 0x2f, 0x47, 0x87, 0x00, 0x1d, //
     0x60, 0xb3, 0x01, 0x84, 0x08, 0x00, 0x45, 0x00, //
     0x00, 0x40, 0xa8, 0xde, 0x40, 0x00, 0x40, 0x06, //
@@ -299,7 +299,7 @@ macro_rules! assert_error {
 
 #[macro_export]
 macro_rules! test_interpreter_and_jit {
-    (override_budget => $override_budget:expr, $executable:expr, $mem:tt, $context_object:expr $(,)?) => {{
+    (override_budget => $override_budget:expr, $executable:expr, $mem:expr, $context_object:expr $(,)?) => {{
         let expected_instruction_count = $context_object.get_remaining();
         #[allow(unused_mut)]
         let mut context_object = $context_object;
@@ -309,9 +309,10 @@ macro_rules! test_interpreter_and_jit {
         }
         let original_budget = context_object.remaining;
         $executable.verify::<RequisiteVerifier>().unwrap();
+        let host_buffer = solana_sbpf::memory_region::HostMemoryObject::host($mem);
+        let mut jit_input_mem = unsafe { Vec::from(host_buffer.ptr().as_ref().unwrap()) };
         let (instruction_count_interpreter, result_interpreter, interpreter_final_pc, _trace_interpreter) = {
-            let mut mem: [u8; _] = $mem;
-            let mem_region = MemoryRegion::new(&raw mut mem, ebpf::MM_INPUT_START);
+            let mem_region = MemoryRegion::new($mem, ebpf::MM_INPUT_START);
             let mut call_frames = vec![
                 solana_sbpf::vm::CallFrame::default();
                 $executable.get_config().max_call_depth
@@ -343,8 +344,12 @@ macro_rules! test_interpreter_and_jit {
             context_object.remaining = original_budget;
             #[allow(unused_mut)]
             let compilation_result = $executable.jit_compile();
-            let mut mem: [u8; _] = $mem;
-            let mem_region = MemoryRegion::new(&raw mut mem, ebpf::MM_INPUT_START);
+            use solana_sbpf::memory_region::HostBuffer;
+            let mem = match host_buffer {
+                HostBuffer::Immutable(_) => HostBuffer::Immutable(&raw const jit_input_mem[..]),
+                HostBuffer::Mutable(_) => HostBuffer::Mutable(&raw mut jit_input_mem[..]),
+            };
+            let mem_region = MemoryRegion::new(mem, ebpf::MM_INPUT_START);
             create_vm!(
                 vm,
                 &$executable,
@@ -386,6 +391,16 @@ macro_rules! test_interpreter_and_jit {
                         );
                         diverged = true;
                     }
+                    unsafe {
+                        let input_after_interp = host_buffer.ptr().as_ref().unwrap();
+                        if input_after_interp != jit_input_mem {
+                            println!(
+                                "input memory buffer is different: interp({:?}), jit({:?})",
+                                input_after_interp, jit_input_mem,
+                            );
+                            diverged = true;
+                        }
+                    }
                     if !compare_register_trace(&_trace_interpreter, trace_jit) {
                         let analysis = Analysis::from_executable(&$executable).unwrap();
                         let stdout = std::io::stdout();
@@ -412,7 +427,7 @@ macro_rules! test_interpreter_and_jit {
         }
         result_interpreter
     }};
-    ($executable:expr, $mem:tt, $context_object:expr, $expected_result:expr $(,)?) => {
+    ($executable:expr, $mem:expr, $context_object:expr, $expected_result:expr $(,)?) => {
         let expected_result = $expected_result;
         let result = test_interpreter_and_jit!(
             override_budget => false,

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -79,6 +79,9 @@ pub fn compare_register_trace(
     interpreter == jit
 }
 
+/// Convenience value to pass to the `test_interpreter_and_jit*` macros to indicate no input.
+pub const NO_INPUT: *const [u8] = std::ptr::slice_from_raw_parts(std::ptr::dangling(), 0);
+
 // Assembly code and data for tcp_sack testcases.
 
 pub const PROG_TCP_PORT_80: &str = "

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -35,6 +35,8 @@ use test_utils::{
     TestContextObject, PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH,
 };
 
+static NO_INPUT_MEM: [u8; 0] = [];
+
 // BPF_ALU32_LOAD : Arithmetic and Logic
 
 #[test]
@@ -44,7 +46,7 @@ fn test_mov32_imm() {
         add64 r10, 0
         mov32 r0, 1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Ok(1),
     );
@@ -53,7 +55,7 @@ fn test_mov32_imm() {
         add64 r10, 0
         mov32 r0, -1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Ok(0xffffffff),
     );
@@ -67,7 +69,7 @@ fn test_mov32_reg() {
         mov32 r1, 1
         mov32 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1),
     );
@@ -77,7 +79,7 @@ fn test_mov32_reg() {
         mov32 r1, -1
         mov32 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0xffffffff),
     );
@@ -90,7 +92,7 @@ fn test_mov64_imm() {
         add64 r10, 0
         mov64 r0, 1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Ok(1),
     );
@@ -99,7 +101,7 @@ fn test_mov64_imm() {
         add64 r10, 0
         mov64 r0, -1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Ok(0xffffffffffffffff),
     );
@@ -113,7 +115,7 @@ fn test_mov64_reg() {
         mov64 r1, 1
         mov64 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1),
     );
@@ -123,7 +125,7 @@ fn test_mov64_reg() {
         mov64 r1, -1
         mov64 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0xffffffffffffffff),
     );
@@ -141,7 +143,7 @@ fn test_bounce() {
         mov r9, r8
         mov r0, r9
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(8),
         ProgramResult::Ok(0x1),
     );
@@ -159,7 +161,7 @@ fn test_add32_sub32() {
         mov32 r1, 3
         sub32 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(8),
         ProgramResult::Ok(5),
     );
@@ -177,7 +179,7 @@ fn test_add64_sub64() {
         mov32 r1, 3
         sub64 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(8),
         ProgramResult::Ok(5),
     );
@@ -185,6 +187,7 @@ fn test_add64_sub64() {
 
 #[test]
 fn test_lmul128() {
+    let mut input = [0; 16];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -230,7 +233,7 @@ fn test_lmul128() {
         or64 r0, r4
         stxdw [r1+0x0], r0
         exit",
-        [0; 16],
+        &raw mut input,
         TestContextObject::new(43),
         ProgramResult::Ok(600),
     );
@@ -262,7 +265,7 @@ fn test_alu32_logic() {
         xor32 r0, 0x03
         xor32 r0, r2
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(22),
         ProgramResult::Ok(0x11),
     );
@@ -296,7 +299,7 @@ fn test_alu64_logic() {
         xor r0, 0x03
         xor r0, r2
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(24),
         ProgramResult::Ok(0x11),
     );
@@ -311,7 +314,7 @@ fn test_arsh32_high_shift() {
         lddw r1, 0x100000001
         arsh32 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x4),
     );
@@ -326,7 +329,7 @@ fn test_arsh32_imm() {
         lsh32 r0, 28
         arsh32 r0, 16
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0xffff8000),
     );
@@ -342,7 +345,7 @@ fn test_arsh32_reg() {
         lsh32 r0, 28
         arsh32 r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Ok(0xffff8000),
     );
@@ -359,7 +362,7 @@ fn test_arsh64() {
         mov32 r1, 5
         arsh r0, r1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(7),
         ProgramResult::Ok(0xfffffffffffffff8),
     );
@@ -374,7 +377,7 @@ fn test_lsh64_reg() {
         mov r7, 4
         lsh r0, r7
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x10),
     );
@@ -389,7 +392,7 @@ fn test_rhs32_imm() {
         add r0, -1
         rsh32 r0, 8
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x00ffffff),
     );
@@ -404,7 +407,7 @@ fn test_rsh64_reg() {
         mov r7, 4
         rsh r0, r7
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x1),
     );
@@ -412,13 +415,14 @@ fn test_rsh64_reg() {
 
 #[test]
 fn test_be16() {
+    let input = [0x11, 0x22];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
         ldxh r0, [r1]
         be16 r0
         exit",
-        [0x11, 0x22],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1122),
     );
@@ -426,13 +430,14 @@ fn test_be16() {
 
 #[test]
 fn test_be16_high() {
+    let input = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
         ldxdw r0, [r1]
         be16 r0
         exit",
-        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1122),
     );
@@ -440,13 +445,14 @@ fn test_be16_high() {
 
 #[test]
 fn test_be32() {
+    let input = [0x11, 0x22, 0x33, 0x44];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
         ldxw r0, [r1]
         be32 r0
         exit",
-        [0x11, 0x22, 0x33, 0x44],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x11223344),
     );
@@ -454,13 +460,14 @@ fn test_be32() {
 
 #[test]
 fn test_be32_high() {
+    let input = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
         ldxdw r0, [r1]
         be32 r0
         exit",
-        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x11223344),
     );
@@ -468,13 +475,14 @@ fn test_be32_high() {
 
 #[test]
 fn test_be64() {
+    let input = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
         ldxdw r0, [r1]
         be64 r0
         exit",
-        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1122334455667788),
     );
@@ -552,7 +560,7 @@ fn test_pqr_v0() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(4),
             ProgramResult::Ok(expected_result),
         );
@@ -567,7 +575,7 @@ fn test_pqr_v0() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(4),
             ProgramResult::Ok(expected_result),
         );
@@ -728,7 +736,7 @@ fn test_pqr_v2() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(7),
             ProgramResult::Ok(expected_result),
         );
@@ -743,7 +751,7 @@ fn test_pqr_v2() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(7),
             ProgramResult::Ok(expected_result),
         );
@@ -783,7 +791,7 @@ fn test_err_pqr_divide_by_zero() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(3),
             ProgramResult::Err(EbpfError::DivideByZero),
         );
@@ -827,7 +835,7 @@ fn test_err_pqr_divide_overflow() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(5),
             ProgramResult::Err(EbpfError::DivideOverflow),
         );
@@ -844,47 +852,55 @@ fn test_memory_instructions() {
             ..Config::default()
         };
 
+        let input = [0xaa, 0xbb, 0x11, 0xcc, 0xdd];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
             ldxb r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0xcc, 0xdd],
+            &raw const input,
             TestContextObject::new(3),
             ProgramResult::Ok(0x11),
         );
+        let input = [0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
             ldxh r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0x22, 0xcc, 0xdd],
+            &raw const input,
             TestContextObject::new(3),
             ProgramResult::Ok(0x2211),
         );
+        let input = [0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
             ldxw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0xcc, 0xdd],
+            &raw const input,
             TestContextObject::new(3),
             ProgramResult::Ok(0x44332211),
         );
+        let input = [
+            0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw const input,
             TestContextObject::new(3),
             ProgramResult::Ok(0x8877665544332211),
         );
-
+        let mut input = [
+            0xaa, 0xbb, 0xff, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -892,10 +908,13 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0x8877665544332211),
         );
+        let mut input = [
+            0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -903,10 +922,13 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0x88776655443322FF),
         );
+        let mut input = [
+            0xaa, 0xbb, 0xff, 0xff, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -914,10 +936,13 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0xff, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0x8877665544332211),
         );
+        let mut input = [
+            0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -925,10 +950,13 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0x887766554433FFFF),
         );
+        let mut input = [
+            0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -936,10 +964,13 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0x8877665544332211),
         );
+        let mut input = [
+            0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -947,10 +978,13 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0x88776655FFFFFFFF),
         );
+        let mut input = [
+            0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -958,10 +992,13 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0x44332211),
         );
+        let mut input = [
+            0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -969,11 +1006,12 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(4),
             ProgramResult::Ok(0xFFFFFFFFFFFFFFFF),
         );
 
+        let mut input = [0xaa, 0xbb, 0xff, 0xcc, 0xdd];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -982,10 +1020,11 @@ fn test_memory_instructions() {
             ldxb r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(5),
             ProgramResult::Ok(0x11),
         );
+        let mut input = [0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -994,10 +1033,11 @@ fn test_memory_instructions() {
             ldxh r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0xff, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(5),
             ProgramResult::Ok(0x2211),
         );
+        let mut input = [0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -1006,10 +1046,13 @@ fn test_memory_instructions() {
             ldxw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(5),
             ProgramResult::Ok(0x44332211),
         );
+        let mut input = [
+            0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd,
+        ];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -1020,7 +1063,7 @@ fn test_memory_instructions() {
             ldxdw r0, [r1+2]
             exit",
             config.clone(),
-            [0xaa, 0xbb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xcc, 0xdd],
+            &raw mut input,
             TestContextObject::new(7),
             ProgramResult::Ok(0x8877665544332211),
         );
@@ -1040,7 +1083,7 @@ fn test_hor64() {
         hor64 r0, 0x01020304
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1122334400000000),
     );
@@ -1048,6 +1091,7 @@ fn test_hor64() {
 
 #[test]
 fn test_ldxh_same_reg() {
+    let mut input = [0xff, 0xff];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1055,7 +1099,7 @@ fn test_ldxh_same_reg() {
         sth [r0], 0x1234
         ldxh r0, [r0]
         exit",
-        [0xff, 0xff],
+        &raw mut input,
         TestContextObject::new(5),
         ProgramResult::Ok(0x1234),
     );
@@ -1063,15 +1107,16 @@ fn test_ldxh_same_reg() {
 
 #[test]
 fn test_err_ldxdw_oob() {
+    let input = [
+        0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, //
+        0x77, 0x88, 0xcc, 0xdd, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
         ldxdw r0, [r1+6]
         exit",
-        [
-            0xaa, 0xbb, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, //
-            0x77, 0x88, 0xcc, 0xdd, //
-        ],
+        &raw const input,
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::AccessViolation(
             AccessType::Load,
@@ -1089,7 +1134,7 @@ fn test_err_ldxdw_nomem() {
         add64 r10, 0
         ldxdw r0, [r1+6]
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::AccessViolation(
             AccessType::Load,
@@ -1102,6 +1147,10 @@ fn test_err_ldxdw_nomem() {
 
 #[test]
 fn test_ldxb_all() {
+    let input = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, //
+        0x08, 0x09, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1136,10 +1185,7 @@ fn test_ldxb_all() {
         or r0, r8
         or r0, r9
         exit",
-        [
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, //
-            0x08, 0x09, //
-        ],
+        &raw const input,
         TestContextObject::new(32),
         ProgramResult::Ok(0x9876543210),
     );
@@ -1147,6 +1193,11 @@ fn test_ldxb_all() {
 
 #[test]
 fn test_ldxh_all() {
+    let input = [
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, //
+        0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, //
+        0x00, 0x08, 0x00, 0x09, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1191,11 +1242,7 @@ fn test_ldxh_all() {
         or r0, r8
         or r0, r9
         exit",
-        [
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03, //
-            0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, //
-            0x00, 0x08, 0x00, 0x09, //
-        ],
+        &raw const input,
         TestContextObject::new(42),
         ProgramResult::Ok(0x9876543210),
     );
@@ -1203,6 +1250,11 @@ fn test_ldxh_all() {
 
 #[test]
 fn test_ldxh_all2() {
+    let input = [
+        0x00, 0x01, 0x00, 0x02, 0x00, 0x04, 0x00, 0x08, //
+        0x00, 0x10, 0x00, 0x20, 0x00, 0x40, 0x00, 0x80, //
+        0x01, 0x00, 0x02, 0x00, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1237,11 +1289,7 @@ fn test_ldxh_all2() {
         or r0, r8
         or r0, r9
         exit",
-        [
-            0x00, 0x01, 0x00, 0x02, 0x00, 0x04, 0x00, 0x08, //
-            0x00, 0x10, 0x00, 0x20, 0x00, 0x40, 0x00, 0x80, //
-            0x01, 0x00, 0x02, 0x00, //
-        ],
+        &raw const input,
         TestContextObject::new(32),
         ProgramResult::Ok(0x3ff),
     );
@@ -1249,6 +1297,13 @@ fn test_ldxh_all2() {
 
 #[test]
 fn test_ldxw_all() {
+    let input = [
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, //
+        0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x08, //
+        0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, //
+        0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x08, 0x00, //
+        0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1283,13 +1338,7 @@ fn test_ldxw_all() {
         or r0, r8
         or r0, r9
         exit",
-        [
-            0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, //
-            0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x08, //
-            0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, //
-            0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x08, 0x00, //
-            0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, //
-        ],
+        &raw const input,
         TestContextObject::new(32),
         ProgramResult::Ok(0x030f0f),
     );
@@ -1297,6 +1346,9 @@ fn test_ldxw_all() {
 
 #[test]
 fn test_stxb_all() {
+    let mut input = [
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1319,9 +1371,7 @@ fn test_stxb_all() {
         ldxdw r0, [r1]
         be64 r0
         exit",
-        [
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, //
-        ],
+        &raw mut input,
         TestContextObject::new(20),
         ProgramResult::Ok(0xf0f2f3f4f5f6f7f8),
     );
@@ -1329,6 +1379,7 @@ fn test_stxb_all() {
 
 #[test]
 fn test_stxb_all2() {
+    let mut input = [0xff, 0xff];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1340,7 +1391,7 @@ fn test_stxb_all2() {
         ldxh r0, [r0]
         be16 r0
         exit",
-        [0xff, 0xff],
+        &raw mut input,
         TestContextObject::new(9),
         ProgramResult::Ok(0xf1f9),
     );
@@ -1348,6 +1399,10 @@ fn test_stxb_all2() {
 
 #[test]
 fn test_stxb_chain() {
+    let mut input = [
+        0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
+        0x00, 0x00, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -1372,10 +1427,7 @@ fn test_stxb_chain() {
         stxb [r0+9], r1
         ldxb r0, [r0+9]
         exit",
-        [
-            0x2a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, //
-            0x00, 0x00, //
-        ],
+        &raw mut input,
         TestContextObject::new(22),
         ProgramResult::Ok(0x2a),
     );
@@ -1396,7 +1448,7 @@ fn test_exit_capped() {
             add64 r10, 0
             exit",
             config,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(1),
             ProgramResult::Err(EbpfError::ExceededMaxInstructions),
         );
@@ -1416,7 +1468,7 @@ fn test_exit_without_value() {
             add64 r10, 0
             exit",
             config,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(2),
             ProgramResult::Ok(0x0),
         );
@@ -1437,7 +1489,7 @@ fn test_exit() {
             mov r0, 0
             exit",
             config,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(3),
             ProgramResult::Ok(0x0),
         );
@@ -1460,7 +1512,7 @@ fn test_early_exit() {
             mov r0, 4
             exit",
             config,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(3),
             ProgramResult::Ok(0x3),
         );
@@ -1477,7 +1529,7 @@ fn test_exit_to_nothing_is_capped() {
             call -2
         "##,
         Config::default(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExecutionOverrun),
     );
@@ -1492,7 +1544,7 @@ fn test_ja() {
         ja +1
         mov r0, 2
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1),
     );
@@ -1572,7 +1624,7 @@ fn test_conditional_jumps() {
             .unwrap();
             test_interpreter_and_jit!(
                 executable,
-                [],
+                &raw const NO_INPUT_MEM,
                 TestContextObject::new(6),
                 ProgramResult::Ok(expected_result as u64),
             );
@@ -1596,7 +1648,7 @@ fn test_stack1() {
         add r2, r1
         ldxdw r0, [r2-16]
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(10),
         ProgramResult::Ok(0xcd),
     );
@@ -1623,7 +1675,7 @@ fn test_stack2() {
         syscall bpf_gather_bytes
         xor r0, 0x2a2a2a2a
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "bpf_mem_frob" => syscalls::SyscallMemFrob,
             "bpf_gather_bytes" => syscalls::SyscallGatherBytes,
@@ -1666,7 +1718,7 @@ fn test_string_stack() {
         jeq r1, r6, +1
         mov r0, 0x0
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "bpf_str_cmp" => syscalls::SyscallStrCmp,
         ),
@@ -1692,7 +1744,7 @@ fn test_err_stack_out_of_bound() {
         stb [r10-0x1001], 0
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(1),
         ProgramResult::Err(EbpfError::StackAccessViolation(
             AccessType::Store,
@@ -1712,7 +1764,7 @@ fn test_err_stack_out_of_bound() {
         stb [r0], 0
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::StackAccessViolation(
             AccessType::Store,
@@ -1740,7 +1792,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         mov r0, r10
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64),
     );
@@ -1773,7 +1825,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         stb [r10], 0
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(12),
         ProgramResult::Err(EbpfError::AccessViolation(
             AccessType::Store,
@@ -1795,7 +1847,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         add r10, 0
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(7),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64 - 64),
     );
@@ -1811,7 +1863,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         mov r0, r10
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64 - 64),
     );
@@ -1828,7 +1880,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         exit
         ",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64),
     );
@@ -1862,7 +1914,7 @@ fn test_entrypoint_exit() {
             mov r0, 12
             exit",
             config,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(7),
             ProgramResult::Ok(42),
         );
@@ -1893,7 +1945,7 @@ fn test_stack_call_depth_tracking() {
             exit
             ",
             config.clone(),
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(8),
             ProgramResult::Ok(0),
         );
@@ -1914,7 +1966,7 @@ fn test_stack_call_depth_tracking() {
             exit
             ",
             config,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(4),
             ProgramResult::Err(EbpfError::CallDepthExceeded),
         );
@@ -1923,7 +1975,7 @@ fn test_stack_call_depth_tracking() {
 
 #[test]
 fn test_err_mem_access_out_of_bound() {
-    let mem = [0; 512];
+    let mut mem = [0; 512];
     let mut prog = [0; 40];
     prog[0] = ebpf::ADD64_IMM;
     prog[1] = 0;
@@ -1953,7 +2005,7 @@ fn test_err_mem_access_out_of_bound() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            mem,
+            &raw mut mem,
             TestContextObject::new(3),
             ProgramResult::Err(EbpfError::AccessViolation(AccessType::Store, address, 1, k)),
         );
@@ -1968,10 +2020,11 @@ fn test_relative_call_sbpfv0() {
         enabled_sbpf_versions: SBPFVersion::V0..=SBPFVersion::V0,
         ..Config::default()
     };
+    let input = [1];
     test_interpreter_and_jit_elf!(
         "tests/elfs/relative_call_sbpfv0.so",
         config,
-        [1],
+        &raw const input,
         (),
         TestContextObject::new(16),
         ProgramResult::Ok(3),
@@ -1984,10 +2037,11 @@ fn test_relative_call_sbpfv3() {
         enabled_sbpf_versions: SBPFVersion::V3..=SBPFVersion::V4,
         ..Config::default()
     };
+    let input = [1];
     test_interpreter_and_jit_elf!(
         "tests/elfs/relative_call.so",
         config,
-        [1],
+        &raw const input,
         (),
         TestContextObject::new(16),
         ProgramResult::Ok(3),
@@ -2016,7 +2070,7 @@ fn test_bpf_to_bpf_scratch_registers() {
         mov64 r8, 0x00
         mov64 r9, 0x00
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(17),
         ProgramResult::Ok(0xFF),
     );
@@ -2033,7 +2087,7 @@ fn test_syscall_parameter_on_stack() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -2057,7 +2111,7 @@ fn test_callx() {
         add64 r10, 0
         mov64 r0, 0x2A
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(10),
         ProgramResult::Ok(42),
     );
@@ -2076,7 +2130,7 @@ fn test_err_callx_oob_low() {
         callx r0
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -2090,7 +2144,7 @@ fn test_err_callx_oob_high() {
         lddw r0, 0x200000000
         callx r0
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -2104,7 +2158,7 @@ fn test_err_callx_oob_max() {
         lddw r0, 0xFFFFFFFFFFFFFFF8
         callx r0
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -2114,7 +2168,7 @@ fn test_err_callx_oob_max() {
 fn test_callx_unaligned_text_section() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/callx_unaligned.so",
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(129),
         ProgramResult::Err(EbpfError::CallDepthExceeded),
@@ -2128,6 +2182,7 @@ fn test_bpf_to_bpf_depth() {
             max_call_depth,
             ..Config::default()
         };
+        let input = [max_call_depth as u8];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -2142,11 +2197,12 @@ fn test_bpf_to_bpf_depth() {
             call function_foo
             exit",
             config.clone(),
-            [max_call_depth as u8],
+            &raw const input,
             TestContextObject::new(max_call_depth as u64 * 5 - 2),
             ProgramResult::Ok(0),
         );
         // The instruction count is lower here because all the `exit`s never run
+        let input = [max_call_depth as u8 + 1];
         test_interpreter_and_jit_asm!(
             "
             add64 r10, 0
@@ -2161,7 +2217,7 @@ fn test_bpf_to_bpf_depth() {
             call function_foo
             exit",
             config,
-            [max_call_depth as u8 + 1],
+            &raw const input,
             TestContextObject::new(max_call_depth as u64 * 4),
             ProgramResult::Err(EbpfError::CallDepthExceeded),
         );
@@ -2183,7 +2239,7 @@ fn test_err_reg_stack_depth() {
             callx r0
             exit",
             config,
-            [],
+            &raw const NO_INPUT_MEM,
             TestContextObject::new(4 * max_call_depth as u64),
             ProgramResult::Err(EbpfError::CallDepthExceeded),
         );
@@ -2209,7 +2265,7 @@ fn test_call_save() {
         or64 r0, r8
         or64 r0, r9
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         (
             0 => syscalls::trash_registers,
         ),
@@ -2219,6 +2275,7 @@ fn test_call_save() {
 
 #[test]
 fn test_err_syscall_string() {
+    let input = [72, 101, 108, 108, 111];
     test_syscall_asm!(
         "
         add64 r10, 0
@@ -2226,7 +2283,7 @@ fn test_err_syscall_string() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
-        [72, 101, 108, 108, 111],
+        &raw const input,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -2237,6 +2294,7 @@ fn test_err_syscall_string() {
 
 #[test]
 fn test_syscall_string() {
+    let input = [72, 101, 108, 108, 111];
     test_syscall_asm!(
         "
         add64 r10, 0
@@ -2244,7 +2302,7 @@ fn test_syscall_string() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
-        [72, 101, 108, 108, 111],
+        &raw const input,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -2266,7 +2324,7 @@ fn test_syscall() {
         syscall bpf_syscall_u64
         mov64 r0, 0x0
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "bpf_syscall_u64" => syscalls::SyscallU64,
         ),
@@ -2287,7 +2345,7 @@ fn test_call_gather_bytes() {
         mov r5, 5
         syscall bpf_gather_bytes
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "bpf_gather_bytes" => syscalls::SyscallGatherBytes,
         ),
@@ -2298,6 +2356,7 @@ fn test_call_gather_bytes() {
 
 #[test]
 fn test_call_memfrob() {
+    let mut input = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
     test_syscall_asm!(
         "
         add64 r10, 0
@@ -2308,9 +2367,7 @@ fn test_call_memfrob() {
         ldxdw r0, [r6]
         be64 r0
         exit",
-        [
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, //
-        ],
+        &raw mut input,
         (
             "bpf_mem_frob" => syscalls::SyscallMemFrob,
         ),
@@ -2361,9 +2418,10 @@ declare_builtin_function!(
                 Arc::new(loader),
             )
             .unwrap();
+            let input =[depth as u8 - 1, throw as u8];
             test_interpreter_and_jit!(
                 executable,
-                [depth as u8 - 1, throw as u8],
+                &raw const input,
                 TestContextObject::new(if throw == 0 { 5 } else { 4 }),
                 expected_result,
             );
@@ -2398,7 +2456,7 @@ fn test_tight_infinite_loop_conditional() {
         add64 r10, 0
         jsge r0, r0, -1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2411,7 +2469,7 @@ fn test_tight_infinite_loop_unconditional() {
         add64 r10, 0
         ja -1
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2426,7 +2484,7 @@ fn test_tight_infinite_recursion() {
         mov64 r3, 0x41414141
         call entrypoint
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2446,7 +2504,7 @@ fn test_tight_infinite_recursion_callx() {
         add64 r10, 0
         callx r8
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(9),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2454,6 +2512,7 @@ fn test_tight_infinite_recursion_callx() {
 
 #[test]
 fn test_instruction_count_syscall() {
+    let input = [72, 101, 108, 108, 111];
     test_syscall_asm!(
         "
         add64 r10, 0
@@ -2461,7 +2520,7 @@ fn test_instruction_count_syscall() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
-        [72, 101, 108, 108, 111],
+        &raw const input,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -2472,6 +2531,7 @@ fn test_instruction_count_syscall() {
 
 #[test]
 fn test_err_instruction_count_syscall_capped() {
+    let input = [72, 101, 108, 108, 111];
     test_syscall_asm!(
         "
         add64 r10, 0
@@ -2479,7 +2539,7 @@ fn test_err_instruction_count_syscall_capped() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
-        [72, 101, 108, 108, 111],
+        &raw const input,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -2502,7 +2562,7 @@ fn test_err_non_terminate_capped() {
         add64 r6, 0x1
         ja -0x8
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(8),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2518,7 +2578,7 @@ fn test_err_non_terminate_capped() {
         add64 r6, 0x1
         ja -0x8
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(1001),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2534,7 +2594,7 @@ fn test_err_capped_before_exception() {
         div64 r1, r2
         mov64 r0, 0x0
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2547,7 +2607,7 @@ fn test_err_capped_before_exception() {
         callx r2
         mov64 r0, 0x0
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2567,7 +2627,7 @@ fn test_err_exit_capped() {
         add64 r10, 0
         exit
         ",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(7),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2584,7 +2644,7 @@ fn test_err_exit_capped() {
         mov r0, r0
         exit
         ",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(8),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2598,7 +2658,7 @@ fn test_err_exit_capped() {
         mov r0, r0
         exit
         ",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2624,7 +2684,7 @@ fn test_far_jumps() {
         or64 r8, 0x18
         callx r8
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(11),
         ProgramResult::Ok(0),
     );
@@ -2650,7 +2710,7 @@ fn test_err_call_unresolved() {
         mov64 r0, 0x0
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(7),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -2665,7 +2725,7 @@ fn test_syscall_static() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/syscall_static.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "log" => syscalls::SyscallString,
         ),
@@ -2683,7 +2743,7 @@ fn test_syscall_reloc_64_32() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/syscall_reloc_64_32_sbpfv0.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "log" => syscalls::SyscallString,
         ),
@@ -2699,7 +2759,7 @@ fn test_reloc_64_64_sbpfv0() {
     //   [ 1] .text             PROGBITS        0000000000000120 000120 000018 00  AX  0   0  8
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_64_sbpfv0.so",
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START + 0x120),
@@ -2712,7 +2772,7 @@ fn test_reloc_64_64() {
     // address of the entrypoint.
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_64.so",
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START),
@@ -2732,7 +2792,7 @@ fn test_reloc_64_relative_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative_sbpfv0.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START + 0x138),
@@ -2750,7 +2810,7 @@ fn test_reloc_64_relative() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_RODATA_START),
@@ -2771,7 +2831,7 @@ fn test_reloc_64_relative_data() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative_data.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(ebpf::MM_RODATA_START),
@@ -2798,7 +2858,7 @@ fn test_reloc_64_relative_data_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative_data_sbpfv0.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START + 0x140),
@@ -2815,7 +2875,7 @@ fn test_load_elf_rodata_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/rodata_section_sbpfv0.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(42),
@@ -2832,7 +2892,7 @@ fn test_load_elf_rodata() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/rodata_section.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(42),
@@ -2851,7 +2911,7 @@ fn test_struct_func_pointer_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/struct_func_pointer_sbpfv0.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(0x102030405060708),
@@ -2862,7 +2922,7 @@ fn test_struct_func_pointer_sbpfv0() {
 fn test_strict_header() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/strict_header.so",
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(5),
         ProgramResult::Ok(42),
@@ -2881,7 +2941,7 @@ fn test_struct_func_pointer() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/struct_func_pointer.so",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(0x102030405060708),
@@ -2905,7 +2965,7 @@ fn test_lmul_loop() {
         add r1, -1
         jne r1, 0x0, -3
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(38),
         ProgramResult::Ok(0x75db9c97),
     );
@@ -2932,7 +2992,7 @@ fn test_prime() {
         mov r0, 0x0
         jne r4, 0x0, -10
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(656),
         ProgramResult::Ok(0x1),
     );
@@ -2940,6 +3000,18 @@ fn test_prime() {
 
 #[test]
 fn test_subnet() {
+    let input = [
+        0x00, 0x00, 0xc0, 0x9f, 0xa0, 0x97, 0x00, 0xa0, //
+        0xcc, 0x3b, 0xbf, 0xfa, 0x08, 0x00, 0x45, 0x10, //
+        0x00, 0x3c, 0x46, 0x3c, 0x40, 0x00, 0x40, 0x06, //
+        0x73, 0x1c, 0xc0, 0xa8, 0x01, 0x02, 0xc0, 0xa8, //
+        0x01, 0x01, 0x06, 0x0e, 0x00, 0x17, 0x99, 0xc5, //
+        0xa0, 0xec, 0x00, 0x00, 0x00, 0x00, 0xa0, 0x02, //
+        0x7d, 0x78, 0xe0, 0xa3, 0x00, 0x00, 0x02, 0x04, //
+        0x05, 0xb4, 0x04, 0x02, 0x08, 0x0a, 0x00, 0x9c, //
+        0x27, 0x24, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, //
+        0x03, 0x00, //
+    ];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -2957,18 +3029,7 @@ fn test_subnet() {
         jeq r1, 0x1a8c0, +1
         mov r0, 0x0
         exit",
-        [
-            0x00, 0x00, 0xc0, 0x9f, 0xa0, 0x97, 0x00, 0xa0, //
-            0xcc, 0x3b, 0xbf, 0xfa, 0x08, 0x00, 0x45, 0x10, //
-            0x00, 0x3c, 0x46, 0x3c, 0x40, 0x00, 0x40, 0x06, //
-            0x73, 0x1c, 0xc0, 0xa8, 0x01, 0x02, 0xc0, 0xa8, //
-            0x01, 0x01, 0x06, 0x0e, 0x00, 0x17, 0x99, 0xc5, //
-            0xa0, 0xec, 0x00, 0x00, 0x00, 0x00, 0xa0, 0x02, //
-            0x7d, 0x78, 0xe0, 0xa3, 0x00, 0x00, 0x02, 0x04, //
-            0x05, 0xb4, 0x04, 0x02, 0x08, 0x0a, 0x00, 0x9c, //
-            0x27, 0x24, 0x00, 0x00, 0x00, 0x00, 0x01, 0x03, //
-            0x03, 0x00, //
-        ],
+        &raw const input,
         TestContextObject::new(12),
         ProgramResult::Ok(0x1),
     );
@@ -2976,23 +3037,24 @@ fn test_subnet() {
 
 #[test]
 fn test_tcp_port80_match() {
+    let input = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
+        0x07, 0x08, 0x09, 0x0a, 0x08, 0x00, 0x45, 0x00, //
+        0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x06, //
+        0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
+        0x00, 0x02, 0x27, 0x10, 0x00, 0x50, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x02, //
+        0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, //
+    ];
     test_interpreter_and_jit_asm!(
         PROG_TCP_PORT_80,
-        [
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
-            0x07, 0x08, 0x09, 0x0a, 0x08, 0x00, 0x45, 0x00, //
-            0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x06, //
-            0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
-            0x00, 0x02, 0x27, 0x10, 0x00, 0x50, 0x00, 0x00, //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x02, //
-            0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, //
-        ],
+        &raw const input,
         TestContextObject::new(18),
         ProgramResult::Ok(0x1),
     );
@@ -3000,23 +3062,24 @@ fn test_tcp_port80_match() {
 
 #[test]
 fn test_tcp_port80_nomatch() {
+    let input = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
+        0x07, 0x08, 0x09, 0x0a, 0x08, 0x00, 0x45, 0x00, //
+        0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x06, //
+        0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
+        0x00, 0x02, 0x00, 0x16, 0x27, 0x10, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x51, 0x02, //
+        0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, //
+    ];
     test_interpreter_and_jit_asm!(
         PROG_TCP_PORT_80,
-        [
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
-            0x07, 0x08, 0x09, 0x0a, 0x08, 0x00, 0x45, 0x00, //
-            0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x06, //
-            0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
-            0x00, 0x02, 0x00, 0x16, 0x27, 0x10, 0x00, 0x00, //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x51, 0x02, //
-            0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, //
-        ],
+        &raw const input,
         TestContextObject::new(19),
         ProgramResult::Ok(0x0),
     );
@@ -3024,23 +3087,24 @@ fn test_tcp_port80_nomatch() {
 
 #[test]
 fn test_tcp_port80_nomatch_ethertype() {
+    let input = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
+        0x07, 0x08, 0x09, 0x0a, 0x08, 0x01, 0x45, 0x00, //
+        0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x06, //
+        0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
+        0x00, 0x02, 0x27, 0x10, 0x00, 0x50, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x02, //
+        0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, //
+    ];
     test_interpreter_and_jit_asm!(
         PROG_TCP_PORT_80,
-        [
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
-            0x07, 0x08, 0x09, 0x0a, 0x08, 0x01, 0x45, 0x00, //
-            0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x06, //
-            0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
-            0x00, 0x02, 0x27, 0x10, 0x00, 0x50, 0x00, 0x00, //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x02, //
-            0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, //
-        ],
+        &raw const input,
         TestContextObject::new(8),
         ProgramResult::Ok(0x0),
     );
@@ -3048,23 +3112,24 @@ fn test_tcp_port80_nomatch_ethertype() {
 
 #[test]
 fn test_tcp_port80_nomatch_proto() {
+    let input = [
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
+        0x07, 0x08, 0x09, 0x0a, 0x08, 0x00, 0x45, 0x00, //
+        0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x11, //
+        0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
+        0x00, 0x02, 0x27, 0x10, 0x00, 0x50, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x02, //
+        0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
+        0x44, 0x44, 0x44, 0x44, //
+    ];
     test_interpreter_and_jit_asm!(
         PROG_TCP_PORT_80,
-        [
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x00, 0x06, //
-            0x07, 0x08, 0x09, 0x0a, 0x08, 0x00, 0x45, 0x00, //
-            0x00, 0x56, 0x00, 0x01, 0x00, 0x00, 0x40, 0x11, //
-            0xf9, 0x4d, 0xc0, 0xa8, 0x00, 0x01, 0xc0, 0xa8, //
-            0x00, 0x02, 0x27, 0x10, 0x00, 0x50, 0x00, 0x00, //
-            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x50, 0x02, //
-            0x20, 0x00, 0xc5, 0x18, 0x00, 0x00, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, //
-            0x44, 0x44, 0x44, 0x44, //
-        ],
+        &raw const input,
         TestContextObject::new(10),
         ProgramResult::Ok(0x0),
     );
@@ -3074,7 +3139,7 @@ fn test_tcp_port80_nomatch_proto() {
 fn test_tcp_sack_match() {
     test_interpreter_and_jit_asm!(
         TCP_SACK_ASM,
-        TCP_SACK_MATCH,
+        &raw const TCP_SACK_MATCH,
         TestContextObject::new(80),
         ProgramResult::Ok(0x1),
     );
@@ -3084,7 +3149,7 @@ fn test_tcp_sack_match() {
 fn test_tcp_sack_nomatch() {
     test_interpreter_and_jit_asm!(
         TCP_SACK_ASM,
-        TCP_SACK_NOMATCH,
+        &raw const TCP_SACK_NOMATCH,
         TestContextObject::new(56),
         ProgramResult::Ok(0x0),
     );
@@ -3219,7 +3284,7 @@ fn test_call_imm_does_not_dispatch_syscalls() {
         add64 r10, 0
         mov r0, 42
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -3238,7 +3303,7 @@ fn test_callx_unsupported_instruction_and_exceeded_max_instructions() {
         add64 r7, 0
         callx r5
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -3259,7 +3324,7 @@ fn test_capped_after_callx() {
         add64 r10, 0
         mov64 r0, 0x2A
         exit",
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3280,7 +3345,7 @@ fn test_err_fixed_stack_out_of_bound() {
         stb [r10-0x4000], 0
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::AccessViolation(
             AccessType::Store,
@@ -3302,7 +3367,7 @@ fn test_execution_overrun() {
         add64 r10, 0
         add r1, 0",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExecutionOverrun),
     );
@@ -3311,7 +3376,7 @@ fn test_execution_overrun() {
         add64 r10, 0
         add r1, 0",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3320,7 +3385,7 @@ fn test_execution_overrun() {
         add64 r10, 0
         add r1, 0",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(1),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3339,7 +3404,7 @@ fn test_mov32_reg_truncating() {
         mov32 r0, r1
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0xffffffff),
     );
@@ -3356,7 +3421,7 @@ fn test_lddw() {
         add64 r10, 0
         lddw r0, 0x1122334455667788",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExecutionOverrun),
     );
@@ -3366,7 +3431,7 @@ fn test_lddw() {
         lddw r0, 0x1122334455667788
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Ok(0x1122334455667788),
     );
@@ -3376,7 +3441,7 @@ fn test_lddw() {
         lddw r0, 0x0000000080000000
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Ok(0x80000000),
     );
@@ -3395,7 +3460,7 @@ fn test_lddw() {
         exit
         ",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(10),
         ProgramResult::Ok(0x2),
     );
@@ -3409,7 +3474,7 @@ fn test_lddw() {
         lddw r0, 0x1122334455667788
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3423,7 +3488,7 @@ fn test_lddw() {
         lddw r0, 0x1122334455667788
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -3440,7 +3505,7 @@ fn test_lddw() {
         exit
         ",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -3456,7 +3521,7 @@ fn test_lddw() {
         exit
         ",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -3469,7 +3534,7 @@ fn test_lddw() {
         exit
         ",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3481,6 +3546,7 @@ fn test_le() {
         enabled_sbpf_versions: SBPFVersion::V0..=SBPFVersion::V0,
         ..Config::default()
     };
+    let input = [0x22, 0x11];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -3488,10 +3554,11 @@ fn test_le() {
         le16 r0
         exit",
         config.clone(),
-        [0x22, 0x11],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1122),
     );
+    let input = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -3499,10 +3566,11 @@ fn test_le() {
         le16 r0
         exit",
         config.clone(),
-        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x2211),
     );
+    let input = [0x44, 0x33, 0x22, 0x11];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -3510,10 +3578,11 @@ fn test_le() {
         le32 r0
         exit",
         config.clone(),
-        [0x44, 0x33, 0x22, 0x11],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x11223344),
     );
+    let input = [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -3521,10 +3590,11 @@ fn test_le() {
         le32 r0
         exit",
         config.clone(),
-        [0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x44332211),
     );
+    let input = [0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11];
     test_interpreter_and_jit_asm!(
         "
         add64 r10, 0
@@ -3532,7 +3602,7 @@ fn test_le() {
         le64 r0
         exit",
         config,
-        [0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11],
+        &raw const input,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1122334455667788),
     );
@@ -3551,7 +3621,7 @@ fn test_neg() {
         neg32 r0
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0xfffffffe),
     );
@@ -3562,7 +3632,7 @@ fn test_neg() {
         neg r0
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0xfffffffffffffffe),
     );
@@ -3573,7 +3643,7 @@ fn test_neg() {
         sub32 r0, 1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(2),
     );
@@ -3584,7 +3654,7 @@ fn test_neg() {
         sub r0, 1
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(2),
     );
@@ -3609,7 +3679,7 @@ fn test_callx_imm() {
         mov64 r0, 0x2A
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(9),
         ProgramResult::Ok(42),
     );
@@ -3628,7 +3698,7 @@ fn test_mul() {
         mul32 r0, 4
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0xc),
     );
@@ -3640,7 +3710,7 @@ fn test_mul() {
         mul32 r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0xc),
     );
@@ -3652,7 +3722,7 @@ fn test_mul() {
         mul32 r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x4),
     );
@@ -3663,7 +3733,7 @@ fn test_mul() {
         mul r0, 4
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0x100000004),
     );
@@ -3675,7 +3745,7 @@ fn test_mul() {
         mul r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x100000004),
     );
@@ -3686,7 +3756,7 @@ fn test_mul() {
         mul32 r0, 4
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0xFFFFFFFFFFFFFFFC),
     );
@@ -3706,7 +3776,7 @@ fn test_div() {
         div32 r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x3),
     );
@@ -3717,7 +3787,7 @@ fn test_div() {
         div32 r0, 4
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0x3),
     );
@@ -3729,7 +3799,7 @@ fn test_div() {
         div32 r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x3),
     );
@@ -3741,7 +3811,7 @@ fn test_div() {
         div r0, 4
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(0x300000000),
     );
@@ -3754,7 +3824,7 @@ fn test_div() {
         div r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Ok(0x300000000),
     );
@@ -3766,7 +3836,7 @@ fn test_div() {
         div r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3778,7 +3848,7 @@ fn test_div() {
         div32 r0, r1
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3799,7 +3869,7 @@ fn test_mod() {
         mod32 r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(6),
         ProgramResult::Ok(0x5),
     );
@@ -3810,7 +3880,7 @@ fn test_mod() {
         mod32 r0, 3
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Ok(0x0),
     );
@@ -3827,7 +3897,7 @@ fn test_mod() {
         mod r0, 0x658f1778
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(10),
         ProgramResult::Ok(0x30ba5a04),
     );
@@ -3839,7 +3909,7 @@ fn test_mod() {
         mod r0, r1
         exit",
         config.clone(),
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3851,7 +3921,7 @@ fn test_mod() {
         mod32 r0, r1
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3860,6 +3930,7 @@ fn test_mod() {
 #[test]
 fn test_symbol_relocation() {
     // No relocation is necessary in SBFPv3
+    let input = [72, 101, 108, 108, 111];
     test_syscall_asm!(
         "
         add64 r10, 64
@@ -3869,7 +3940,7 @@ fn test_symbol_relocation() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
-        [72, 101, 108, 108, 111],
+        &raw const input,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -3894,7 +3965,7 @@ fn test_stack_gaps() {
         ldxdw r0, [r10 - 4088]
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(1),
         ProgramResult::Err(EbpfError::StackAccessViolation(
             AccessType::Store,
@@ -3918,7 +3989,7 @@ fn test_stack_gaps() {
         ldxdw r0, [r10 - 4088]
         exit",
         config,
-        [],
+        &raw const NO_INPUT_MEM,
         TestContextObject::new(5),
         ProgramResult::Ok(77),
     );

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -32,10 +32,8 @@ use std::{fs::File, io::Read, sync::Arc};
 use test_utils::{
     assert_error, compare_register_trace, create_vm, syscalls, test_interpreter_and_jit,
     test_interpreter_and_jit_asm, test_interpreter_and_jit_elf, test_syscall_asm,
-    TestContextObject, PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH,
+    TestContextObject, NO_INPUT, PROG_TCP_PORT_80, TCP_SACK_ASM, TCP_SACK_MATCH, TCP_SACK_NOMATCH,
 };
-
-static NO_INPUT_MEM: [u8; 0] = [];
 
 // BPF_ALU32_LOAD : Arithmetic and Logic
 
@@ -46,7 +44,7 @@ fn test_mov32_imm() {
         add64 r10, 0
         mov32 r0, 1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Ok(1),
     );
@@ -55,7 +53,7 @@ fn test_mov32_imm() {
         add64 r10, 0
         mov32 r0, -1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Ok(0xffffffff),
     );
@@ -69,7 +67,7 @@ fn test_mov32_reg() {
         mov32 r1, 1
         mov32 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1),
     );
@@ -79,7 +77,7 @@ fn test_mov32_reg() {
         mov32 r1, -1
         mov32 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0xffffffff),
     );
@@ -92,7 +90,7 @@ fn test_mov64_imm() {
         add64 r10, 0
         mov64 r0, 1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Ok(1),
     );
@@ -101,7 +99,7 @@ fn test_mov64_imm() {
         add64 r10, 0
         mov64 r0, -1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Ok(0xffffffffffffffff),
     );
@@ -115,7 +113,7 @@ fn test_mov64_reg() {
         mov64 r1, 1
         mov64 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1),
     );
@@ -125,7 +123,7 @@ fn test_mov64_reg() {
         mov64 r1, -1
         mov64 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0xffffffffffffffff),
     );
@@ -143,7 +141,7 @@ fn test_bounce() {
         mov r9, r8
         mov r0, r9
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(8),
         ProgramResult::Ok(0x1),
     );
@@ -161,7 +159,7 @@ fn test_add32_sub32() {
         mov32 r1, 3
         sub32 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(8),
         ProgramResult::Ok(5),
     );
@@ -179,7 +177,7 @@ fn test_add64_sub64() {
         mov32 r1, 3
         sub64 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(8),
         ProgramResult::Ok(5),
     );
@@ -265,7 +263,7 @@ fn test_alu32_logic() {
         xor32 r0, 0x03
         xor32 r0, r2
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(22),
         ProgramResult::Ok(0x11),
     );
@@ -299,7 +297,7 @@ fn test_alu64_logic() {
         xor r0, 0x03
         xor r0, r2
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(24),
         ProgramResult::Ok(0x11),
     );
@@ -314,7 +312,7 @@ fn test_arsh32_high_shift() {
         lddw r1, 0x100000001
         arsh32 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x4),
     );
@@ -329,7 +327,7 @@ fn test_arsh32_imm() {
         lsh32 r0, 28
         arsh32 r0, 16
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0xffff8000),
     );
@@ -345,7 +343,7 @@ fn test_arsh32_reg() {
         lsh32 r0, 28
         arsh32 r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Ok(0xffff8000),
     );
@@ -362,7 +360,7 @@ fn test_arsh64() {
         mov32 r1, 5
         arsh r0, r1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(7),
         ProgramResult::Ok(0xfffffffffffffff8),
     );
@@ -377,7 +375,7 @@ fn test_lsh64_reg() {
         mov r7, 4
         lsh r0, r7
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x10),
     );
@@ -392,7 +390,7 @@ fn test_rhs32_imm() {
         add r0, -1
         rsh32 r0, 8
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x00ffffff),
     );
@@ -407,7 +405,7 @@ fn test_rsh64_reg() {
         mov r7, 4
         rsh r0, r7
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x1),
     );
@@ -560,7 +558,7 @@ fn test_pqr_v0() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(4),
             ProgramResult::Ok(expected_result),
         );
@@ -575,7 +573,7 @@ fn test_pqr_v0() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(4),
             ProgramResult::Ok(expected_result),
         );
@@ -736,7 +734,7 @@ fn test_pqr_v2() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(7),
             ProgramResult::Ok(expected_result),
         );
@@ -751,7 +749,7 @@ fn test_pqr_v2() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(7),
             ProgramResult::Ok(expected_result),
         );
@@ -791,7 +789,7 @@ fn test_err_pqr_divide_by_zero() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(3),
             ProgramResult::Err(EbpfError::DivideByZero),
         );
@@ -835,7 +833,7 @@ fn test_err_pqr_divide_overflow() {
         .unwrap();
         test_interpreter_and_jit!(
             executable,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(5),
             ProgramResult::Err(EbpfError::DivideOverflow),
         );
@@ -1083,7 +1081,7 @@ fn test_hor64() {
         hor64 r0, 0x01020304
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1122334400000000),
     );
@@ -1134,7 +1132,7 @@ fn test_err_ldxdw_nomem() {
         add64 r10, 0
         ldxdw r0, [r1+6]
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::AccessViolation(
             AccessType::Load,
@@ -1448,7 +1446,7 @@ fn test_exit_capped() {
             add64 r10, 0
             exit",
             config,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(1),
             ProgramResult::Err(EbpfError::ExceededMaxInstructions),
         );
@@ -1468,7 +1466,7 @@ fn test_exit_without_value() {
             add64 r10, 0
             exit",
             config,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(2),
             ProgramResult::Ok(0x0),
         );
@@ -1489,7 +1487,7 @@ fn test_exit() {
             mov r0, 0
             exit",
             config,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(3),
             ProgramResult::Ok(0x0),
         );
@@ -1512,7 +1510,7 @@ fn test_early_exit() {
             mov r0, 4
             exit",
             config,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(3),
             ProgramResult::Ok(0x3),
         );
@@ -1529,7 +1527,7 @@ fn test_exit_to_nothing_is_capped() {
             call -2
         "##,
         Config::default(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExecutionOverrun),
     );
@@ -1544,7 +1542,7 @@ fn test_ja() {
         ja +1
         mov r0, 2
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0x1),
     );
@@ -1624,7 +1622,7 @@ fn test_conditional_jumps() {
             .unwrap();
             test_interpreter_and_jit!(
                 executable,
-                &raw const NO_INPUT_MEM,
+                NO_INPUT,
                 TestContextObject::new(6),
                 ProgramResult::Ok(expected_result as u64),
             );
@@ -1648,7 +1646,7 @@ fn test_stack1() {
         add r2, r1
         ldxdw r0, [r2-16]
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(10),
         ProgramResult::Ok(0xcd),
     );
@@ -1675,7 +1673,7 @@ fn test_stack2() {
         syscall bpf_gather_bytes
         xor r0, 0x2a2a2a2a
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "bpf_mem_frob" => syscalls::SyscallMemFrob,
             "bpf_gather_bytes" => syscalls::SyscallGatherBytes,
@@ -1718,7 +1716,7 @@ fn test_string_stack() {
         jeq r1, r6, +1
         mov r0, 0x0
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "bpf_str_cmp" => syscalls::SyscallStrCmp,
         ),
@@ -1744,7 +1742,7 @@ fn test_err_stack_out_of_bound() {
         stb [r10-0x1001], 0
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(1),
         ProgramResult::Err(EbpfError::StackAccessViolation(
             AccessType::Store,
@@ -1764,7 +1762,7 @@ fn test_err_stack_out_of_bound() {
         stb [r0], 0
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::StackAccessViolation(
             AccessType::Store,
@@ -1792,7 +1790,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         mov r0, r10
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64),
     );
@@ -1825,7 +1823,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         stb [r10], 0
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(12),
         ProgramResult::Err(EbpfError::AccessViolation(
             AccessType::Store,
@@ -1847,7 +1845,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         add r10, 0
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(7),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64 - 64),
     );
@@ -1863,7 +1861,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         mov r0, r10
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64 - 64),
     );
@@ -1880,7 +1878,7 @@ fn test_dynamic_stack_frames_sbpfv1() {
         exit
         ",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Ok(ebpf::MM_STACK_START + config.stack_size() as u64),
     );
@@ -1914,7 +1912,7 @@ fn test_entrypoint_exit() {
             mov r0, 12
             exit",
             config,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(7),
             ProgramResult::Ok(42),
         );
@@ -1945,7 +1943,7 @@ fn test_stack_call_depth_tracking() {
             exit
             ",
             config.clone(),
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(8),
             ProgramResult::Ok(0),
         );
@@ -1966,7 +1964,7 @@ fn test_stack_call_depth_tracking() {
             exit
             ",
             config,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(4),
             ProgramResult::Err(EbpfError::CallDepthExceeded),
         );
@@ -2070,7 +2068,7 @@ fn test_bpf_to_bpf_scratch_registers() {
         mov64 r8, 0x00
         mov64 r9, 0x00
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(17),
         ProgramResult::Ok(0xFF),
     );
@@ -2087,7 +2085,7 @@ fn test_syscall_parameter_on_stack() {
         syscall bpf_syscall_string
         mov64 r0, 0x0
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -2111,7 +2109,7 @@ fn test_callx() {
         add64 r10, 0
         mov64 r0, 0x2A
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(10),
         ProgramResult::Ok(42),
     );
@@ -2130,7 +2128,7 @@ fn test_err_callx_oob_low() {
         callx r0
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -2144,7 +2142,7 @@ fn test_err_callx_oob_high() {
         lddw r0, 0x200000000
         callx r0
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -2158,7 +2156,7 @@ fn test_err_callx_oob_max() {
         lddw r0, 0xFFFFFFFFFFFFFFF8
         callx r0
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -2168,7 +2166,7 @@ fn test_err_callx_oob_max() {
 fn test_callx_unaligned_text_section() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/callx_unaligned.so",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(129),
         ProgramResult::Err(EbpfError::CallDepthExceeded),
@@ -2239,7 +2237,7 @@ fn test_err_reg_stack_depth() {
             callx r0
             exit",
             config,
-            &raw const NO_INPUT_MEM,
+            NO_INPUT,
             TestContextObject::new(4 * max_call_depth as u64),
             ProgramResult::Err(EbpfError::CallDepthExceeded),
         );
@@ -2265,7 +2263,7 @@ fn test_call_save() {
         or64 r0, r8
         or64 r0, r9
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             0 => syscalls::trash_registers,
         ),
@@ -2324,7 +2322,7 @@ fn test_syscall() {
         syscall bpf_syscall_u64
         mov64 r0, 0x0
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "bpf_syscall_u64" => syscalls::SyscallU64,
         ),
@@ -2345,7 +2343,7 @@ fn test_call_gather_bytes() {
         mov r5, 5
         syscall bpf_gather_bytes
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "bpf_gather_bytes" => syscalls::SyscallGatherBytes,
         ),
@@ -2456,7 +2454,7 @@ fn test_tight_infinite_loop_conditional() {
         add64 r10, 0
         jsge r0, r0, -1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2469,7 +2467,7 @@ fn test_tight_infinite_loop_unconditional() {
         add64 r10, 0
         ja -1
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2484,7 +2482,7 @@ fn test_tight_infinite_recursion() {
         mov64 r3, 0x41414141
         call entrypoint
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2504,7 +2502,7 @@ fn test_tight_infinite_recursion_callx() {
         add64 r10, 0
         callx r8
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(9),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2562,7 +2560,7 @@ fn test_err_non_terminate_capped() {
         add64 r6, 0x1
         ja -0x8
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(8),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2578,7 +2576,7 @@ fn test_err_non_terminate_capped() {
         add64 r6, 0x1
         ja -0x8
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(1001),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2594,7 +2592,7 @@ fn test_err_capped_before_exception() {
         div64 r1, r2
         mov64 r0, 0x0
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2607,7 +2605,7 @@ fn test_err_capped_before_exception() {
         callx r2
         mov64 r0, 0x0
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2627,7 +2625,7 @@ fn test_err_exit_capped() {
         add64 r10, 0
         exit
         ",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(7),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2644,7 +2642,7 @@ fn test_err_exit_capped() {
         mov r0, r0
         exit
         ",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(8),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2658,7 +2656,7 @@ fn test_err_exit_capped() {
         mov r0, r0
         exit
         ",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -2684,7 +2682,7 @@ fn test_far_jumps() {
         or64 r8, 0x18
         callx r8
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(11),
         ProgramResult::Ok(0),
     );
@@ -2710,7 +2708,7 @@ fn test_err_call_unresolved() {
         mov64 r0, 0x0
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(7),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -2725,7 +2723,7 @@ fn test_syscall_static() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/syscall_static.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "log" => syscalls::SyscallString,
         ),
@@ -2743,7 +2741,7 @@ fn test_syscall_reloc_64_32() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/syscall_reloc_64_32_sbpfv0.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "log" => syscalls::SyscallString,
         ),
@@ -2759,7 +2757,7 @@ fn test_reloc_64_64_sbpfv0() {
     //   [ 1] .text             PROGBITS        0000000000000120 000120 000018 00  AX  0   0  8
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_64_sbpfv0.so",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START + 0x120),
@@ -2772,7 +2770,7 @@ fn test_reloc_64_64() {
     // address of the entrypoint.
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_64.so",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START),
@@ -2792,7 +2790,7 @@ fn test_reloc_64_relative_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative_sbpfv0.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START + 0x138),
@@ -2810,7 +2808,7 @@ fn test_reloc_64_relative() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(ebpf::MM_RODATA_START),
@@ -2831,7 +2829,7 @@ fn test_reloc_64_relative_data() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative_data.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(ebpf::MM_RODATA_START),
@@ -2858,7 +2856,7 @@ fn test_reloc_64_relative_data_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/reloc_64_relative_data_sbpfv0.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(ebpf::MM_BYTECODE_START + 0x140),
@@ -2875,7 +2873,7 @@ fn test_load_elf_rodata_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/rodata_section_sbpfv0.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(42),
@@ -2892,7 +2890,7 @@ fn test_load_elf_rodata() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/rodata_section.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(3),
         ProgramResult::Ok(42),
@@ -2911,7 +2909,7 @@ fn test_struct_func_pointer_sbpfv0() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/struct_func_pointer_sbpfv0.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(0x102030405060708),
@@ -2922,7 +2920,7 @@ fn test_struct_func_pointer_sbpfv0() {
 fn test_strict_header() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/strict_header.so",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(5),
         ProgramResult::Ok(42),
@@ -2941,7 +2939,7 @@ fn test_struct_func_pointer() {
     test_interpreter_and_jit_elf!(
         "tests/elfs/struct_func_pointer.so",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (),
         TestContextObject::new(2),
         ProgramResult::Ok(0x102030405060708),
@@ -2965,7 +2963,7 @@ fn test_lmul_loop() {
         add r1, -1
         jne r1, 0x0, -3
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(38),
         ProgramResult::Ok(0x75db9c97),
     );
@@ -2992,7 +2990,7 @@ fn test_prime() {
         mov r0, 0x0
         jne r4, 0x0, -10
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(656),
         ProgramResult::Ok(0x1),
     );
@@ -3284,7 +3282,7 @@ fn test_call_imm_does_not_dispatch_syscalls() {
         add64 r10, 0
         mov r0, 42
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         (
             "bpf_syscall_string" => syscalls::SyscallString,
         ),
@@ -3303,7 +3301,7 @@ fn test_callx_unsupported_instruction_and_exceeded_max_instructions() {
         add64 r7, 0
         callx r5
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::CallOutsideTextSegment),
     );
@@ -3324,7 +3322,7 @@ fn test_capped_after_callx() {
         add64 r10, 0
         mov64 r0, 0x2A
         exit",
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3345,7 +3343,7 @@ fn test_err_fixed_stack_out_of_bound() {
         stb [r10-0x4000], 0
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::AccessViolation(
             AccessType::Store,
@@ -3367,7 +3365,7 @@ fn test_execution_overrun() {
         add64 r10, 0
         add r1, 0",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExecutionOverrun),
     );
@@ -3376,7 +3374,7 @@ fn test_execution_overrun() {
         add64 r10, 0
         add r1, 0",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(2),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3385,7 +3383,7 @@ fn test_execution_overrun() {
         add64 r10, 0
         add r1, 0",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(1),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3404,7 +3402,7 @@ fn test_mov32_reg_truncating() {
         mov32 r0, r1
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0xffffffff),
     );
@@ -3421,7 +3419,7 @@ fn test_lddw() {
         add64 r10, 0
         lddw r0, 0x1122334455667788",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExecutionOverrun),
     );
@@ -3431,7 +3429,7 @@ fn test_lddw() {
         lddw r0, 0x1122334455667788
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Ok(0x1122334455667788),
     );
@@ -3441,7 +3439,7 @@ fn test_lddw() {
         lddw r0, 0x0000000080000000
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Ok(0x80000000),
     );
@@ -3460,7 +3458,7 @@ fn test_lddw() {
         exit
         ",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(10),
         ProgramResult::Ok(0x2),
     );
@@ -3474,7 +3472,7 @@ fn test_lddw() {
         lddw r0, 0x1122334455667788
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3488,7 +3486,7 @@ fn test_lddw() {
         lddw r0, 0x1122334455667788
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -3505,7 +3503,7 @@ fn test_lddw() {
         exit
         ",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -3521,7 +3519,7 @@ fn test_lddw() {
         exit
         ",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::UnsupportedInstruction),
     );
@@ -3534,7 +3532,7 @@ fn test_lddw() {
         exit
         ",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(3),
         ProgramResult::Err(EbpfError::ExceededMaxInstructions),
     );
@@ -3621,7 +3619,7 @@ fn test_neg() {
         neg32 r0
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0xfffffffe),
     );
@@ -3632,7 +3630,7 @@ fn test_neg() {
         neg r0
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0xfffffffffffffffe),
     );
@@ -3643,7 +3641,7 @@ fn test_neg() {
         sub32 r0, 1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(2),
     );
@@ -3654,7 +3652,7 @@ fn test_neg() {
         sub r0, 1
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(2),
     );
@@ -3679,7 +3677,7 @@ fn test_callx_imm() {
         mov64 r0, 0x2A
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(9),
         ProgramResult::Ok(42),
     );
@@ -3698,7 +3696,7 @@ fn test_mul() {
         mul32 r0, 4
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0xc),
     );
@@ -3710,7 +3708,7 @@ fn test_mul() {
         mul32 r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0xc),
     );
@@ -3722,7 +3720,7 @@ fn test_mul() {
         mul32 r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x4),
     );
@@ -3733,7 +3731,7 @@ fn test_mul() {
         mul r0, 4
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0x100000004),
     );
@@ -3745,7 +3743,7 @@ fn test_mul() {
         mul r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x100000004),
     );
@@ -3756,7 +3754,7 @@ fn test_mul() {
         mul32 r0, 4
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0xFFFFFFFFFFFFFFFC),
     );
@@ -3776,7 +3774,7 @@ fn test_div() {
         div32 r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x3),
     );
@@ -3787,7 +3785,7 @@ fn test_div() {
         div32 r0, 4
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0x3),
     );
@@ -3799,7 +3797,7 @@ fn test_div() {
         div32 r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x3),
     );
@@ -3811,7 +3809,7 @@ fn test_div() {
         div r0, 4
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(0x300000000),
     );
@@ -3824,7 +3822,7 @@ fn test_div() {
         div r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Ok(0x300000000),
     );
@@ -3836,7 +3834,7 @@ fn test_div() {
         div r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3848,7 +3846,7 @@ fn test_div() {
         div32 r0, r1
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3869,7 +3867,7 @@ fn test_mod() {
         mod32 r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(6),
         ProgramResult::Ok(0x5),
     );
@@ -3880,7 +3878,7 @@ fn test_mod() {
         mod32 r0, 3
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Ok(0x0),
     );
@@ -3897,7 +3895,7 @@ fn test_mod() {
         mod r0, 0x658f1778
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(10),
         ProgramResult::Ok(0x30ba5a04),
     );
@@ -3909,7 +3907,7 @@ fn test_mod() {
         mod r0, r1
         exit",
         config.clone(),
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3921,7 +3919,7 @@ fn test_mod() {
         mod32 r0, r1
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(4),
         ProgramResult::Err(EbpfError::DivideByZero),
     );
@@ -3965,7 +3963,7 @@ fn test_stack_gaps() {
         ldxdw r0, [r10 - 4088]
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(1),
         ProgramResult::Err(EbpfError::StackAccessViolation(
             AccessType::Store,
@@ -3989,7 +3987,7 @@ fn test_stack_gaps() {
         ldxdw r0, [r10 - 4088]
         exit",
         config,
-        &raw const NO_INPUT_MEM,
+        NO_INPUT,
         TestContextObject::new(5),
         ProgramResult::Ok(77),
     );

--- a/tests/exercise_instructions.rs
+++ b/tests/exercise_instructions.rs
@@ -452,7 +452,7 @@ fn test_ins(is_v2_only: bool, ins: String, prng: &mut SmallRng, cu: Option<u64>)
     test_interpreter_and_jit!(
         override_budget => true,
         executable,
-        input,
+        &raw mut input,
         TestContextObject::new(cu),
     );
 }


### PR DESCRIPTION
I was going to write an execution test for #196 and found that I couldn't easily test the input memory contents afterwards. Ended up expanding the testing infrastructure to check that the input buffer stays the same between the interpreter and the jit after the execution and it now utilizes the new HostMmeoryObject infrastructure to signal if the test expects that memory to be immutable or mutable (which is a nice additional check to have as well.)