### PR TITLE
jit: improve trampoline code for callx reg

### DIFF
--- a/src/jit.rs
+++ b/src/jit.rs
@@ -1579,6 +1579,7 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         // Routine for emit_internal_call(Value::Register())
         // Inputs: Guest current pc in X86IndirectAccess::OffsetIndexShift(-16, RSP, 0), Guest target address in REGISTER_SCRATCH
         // Outputs: Guest current pc in X86IndirectAccess::OffsetIndexShift(-16, RSP, 0), Guest target pc in REGISTER_SCRATCH, Host target address in RIP
+        // Clobbers: X86IndirectAccess::OffsetIndexShift(-8, RSP, 0) and X86IndirectAccess::OffsetIndexShift(-24, RSP, 0)
         self.set_anchor(ANCHOR_INTERNAL_FUNCTION_CALL_REG);
         self.emit_ins(X86Instruction::push(REGISTER_MAP[0], None));
         // Calculate offset relative to program_vm_addr
@@ -1608,13 +1609,12 @@ impl<'a, C: ContextObject> JitCompiler<'a, C> {
         self.emit_ins(X86Instruction::alu_immediate(OperandSize::S64, 0x81, 5, REGISTER_INSTRUCTION_METER, 1, None)); // instruction_meter -= 1;
         self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_INSTRUCTION_METER, None)); // instruction_meter += guest_target_pc;
         // Offset host_target_address by self.result.text_section
-        self.emit_ins(X86Instruction::mov_mmx(OperandSize::S64, REGISTER_SCRATCH, MM0));
-        self.emit_ins(X86Instruction::load_immediate(REGISTER_SCRATCH, self.result.text_section.as_ptr() as i64)); // REGISTER_SCRATCH = self.result.text_section;
-        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_SCRATCH, REGISTER_MAP[0], None)); // host_target_address += self.result.text_section;
-        self.emit_ins(X86Instruction::mov_mmx(OperandSize::S64, MM0, REGISTER_SCRATCH));
+        self.emit_ins(X86Instruction::store(OperandSize::S64, REGISTER_MAP[0], RSP, X86IndirectAccess::OffsetIndexShift(-16, RSP, 0)));
+        self.emit_ins(X86Instruction::load_immediate(REGISTER_MAP[0], self.result.text_section.as_ptr() as i64)); // RAX = self.result.text_section;
+        self.emit_ins(X86Instruction::alu(OperandSize::S64, 0x01, REGISTER_MAP[0], RSP, Some(X86IndirectAccess::OffsetIndexShift(-16, RSP, 0)))); // host_target_address += self.result.text_section;
         // Restore the clobbered REGISTER_MAP[0]
-        self.emit_ins(X86Instruction::xchg(OperandSize::S64, REGISTER_MAP[0], RSP, Some(X86IndirectAccess::OffsetIndexShift(0, RSP, 0)))); // Swap REGISTER_MAP[0] and host_target_address
-        self.emit_ins(X86Instruction::return_near()); // Tail call to host_target_address
+        self.emit_ins(X86Instruction::pop(REGISTER_MAP[0]));
+        self.emit_ins(X86Instruction::jump_reg(RSP, Some(X86IndirectAccess::OffsetIndexShift(-24, RSP, 0)))); // Tail call to host_target_address
 
         // Translates a vm memory address to a host memory address
         let lower_key = self.immediate_value_key as i32 as i64;


### PR DESCRIPTION
There are three issues in the generated code here:

* Use of MMX as detailed in #197;
* Bus-locking xchg with the stack memory (gigaslow);
* RAS (return address stack) tracking violation which will result in branch mispredict on the next proper return (gigaslow);

These are all addressed by using an additional stack slot above (below?) the "guest current pc" that is marked as an output. I haven't tried to determine if this requirement is actually required for the correct operation (clobbering it didn't seem to cause any problems,) so I took what I believe to be the safe approach.

One caveat is that this code deepens the red zone in this part of the code (with the only other part of the code that relies on as much as 32 bytes of red zone being the related `emit_internal_call` function.) This red zone only exists on linux systems and cannot be used on e.g. windows targets. But this condition is pre-existing, so there should be no problems with this approach...

Fixes #197
Depends on #198 for CI to pass