### PR TITLE
Avoid calloc in parse_ro_sections

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -971,7 +971,9 @@ impl<C: ContextObject> Executable<C> {
                 return Err(ElfError::ValueOutOfBounds);
             }
 
-            let mut ro_section = vec![0; buf_len];
+            #[expect(clippy::slow_vector_initialization)]
+            let mut ro_section = Vec::with_capacity(buf_len);
+            ro_section.resize(buf_len, 0);
             for (section_addr, slice) in ro_slices.iter() {
                 let buf_offset_start = section_addr.saturating_sub(lowest_addr);
                 ro_section[buf_offset_start..buf_offset_start.saturating_add(slice.len())]


### PR DESCRIPTION
#### Problem 
Constructing an owned ELF read-only section currently starts with:

```rust
vec![0; buf_len]
```

This forwards to the allocator's `alloc_zeroed`. This is preventing jemalloc from reusing warm, dirty extents -- it must zero / purge memory or obtain fresh zero-filled pages. Here, it is reliably doing the latter:


<img width="1919" height="737" alt="Screenshot 2026-08-03 163716" src="https://github.com/user-attachments/assets/31b4aae1-4e57-4920-af89-337c756ffaf1" />

#### Solution

Allocate the RO-section buffer through `alloc` and initialize its contents explicitly with `Vec::resize`.

This allows jemalloc to reuse warm dirty extents without the zeroing requirement.

<img width="1919" height="737" alt="Screenshot 2026-08-03 165801" src="https://github.com/user-attachments/assets/cd0bfa3b-446c-4a17-9728-16d0638ffb19" />



