### PR TITLE
elf: reject .text at the bytecode region boundary

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -702,7 +702,7 @@ impl<C: ContextObject> Executable<C> {
         let text_section = get_section(&elf, b".text")?;
         let text_section_vaddr = text_section.sh_addr.saturating_add(ebpf::MM_REGION_SIZE);
         if (config.reject_broken_elfs && text_section.sh_addr != text_section.sh_offset)
-            || text_section_vaddr > ebpf::MM_STACK_START
+            || text_section_vaddr >= ebpf::MM_STACK_START
         {
             return Err(ElfError::ValueOutOfBounds);
         }

--- a/tests/elf.rs
+++ b/tests/elf.rs
@@ -259,6 +259,45 @@ fn test_entrypoint() {
     assert_eq!(4, executable.get_entrypoint_instruction_offset());
 }
 
+#[test]
+fn test_text_section_at_region_boundary() {
+    let mut elf_bytes =
+        std::fs::read("tests/elfs/relative_call_sbpfv0.so").expect("failed to read elf file");
+
+    let (shdr_offset, mut shdr, e_entry) = {
+        let elf = Elf64::parse(&elf_bytes).unwrap();
+        let header = elf.file_header();
+        let (index, section) = elf
+            .section_header_table()
+            .iter()
+            .enumerate()
+            .find(|(_, section)| elf.section_name(section.sh_name).ok() == Some(&b".text"[..]))
+            .unwrap();
+        (
+            header.e_shoff as usize + index * header.e_shentsize as usize,
+            section.clone(),
+            header.e_entry,
+        )
+    };
+
+    let new_e_entry = ebpf::MM_REGION_SIZE + (e_entry - shdr.sh_addr);
+    shdr.sh_addr = ebpf::MM_REGION_SIZE;
+    unsafe {
+        std::ptr::write_unaligned(
+            elf_bytes.as_mut_ptr().add(shdr_offset).cast::<Elf64Shdr>(),
+            shdr,
+        );
+        let mut header = Elf64::parse(&elf_bytes).unwrap().file_header().clone();
+        header.e_entry = new_e_entry;
+        std::ptr::write(elf_bytes.as_mut_ptr().cast::<Elf64Ehdr>(), header);
+    }
+
+    assert!(matches!(
+        ElfExecutable::load(&elf_bytes, loader()),
+        Err(ElfError::ValueOutOfBounds)
+    ));
+}
+
 fn new_section(sh_addr: u64, sh_size: u64) -> Elf64Shdr {
     Elf64Shdr {
         sh_addr,


### PR DESCRIPTION
A .text section with `sh_addr == MM_REGION_SIZE` mapped to a vaddr of exactly `MM_STACK_START`, which an off-by-one check lets through the `load` step. The owned ro_section offset adds `MM_REGION_SIZE` only when the sections are below it, so the two disagreed by one region and `get_text_bytes()` sliced out of bounds.

Fixes the off-by-one and adds a test.

Reported by a few clankers in GHSAs since it can make `verify` panic.