### PR TITLE
Create local verifier for SBPFv3

### DIFF
--- a/fuzz/fuzz_targets/dumb_jit_diff.rs
+++ b/fuzz/fuzz_targets/dumb_jit_diff.rs
@@ -29,7 +29,7 @@ fuzz_target!(|data: DumbFuzzData| {
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
 
-    if RequisiteVerifier::verify(&prog, &config, sbpf_version).is_err() {
+    if RequisiteVerifier::verify(&prog, sbpf_version, &function_registry).is_err() {
         // verify please
         return;
     }

--- a/fuzz/fuzz_targets/dumb_verify.rs
+++ b/fuzz/fuzz_targets/dumb_verify.rs
@@ -31,7 +31,7 @@ fuzz_target!(|data: DumbFuzzData| {
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
 
-    if RequisiteVerifier::verify(&prog, &config, sbpf_version).is_err() {
+    if RequisiteVerifier::verify(&prog, sbpf_version, &function_registry).is_err() {
         // verify please
         return;
     }

--- a/fuzz/fuzz_targets/smart_jit_diff.rs
+++ b/fuzz/fuzz_targets/smart_jit_diff.rs
@@ -42,7 +42,7 @@ fuzz_target!(|data: FuzzData| {
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
 
-    if RequisiteVerifier::verify(prog.into_bytes(), &config, sbpf_version).is_err() {
+    if RequisiteVerifier::verify(prog.into_bytes(), sbpf_version, &function_registry).is_err() {
         // verify please
         return;
     }

--- a/fuzz/fuzz_targets/smart_verify.rs
+++ b/fuzz/fuzz_targets/smart_verify.rs
@@ -34,7 +34,7 @@ fuzz_target!(|data: FuzzData| {
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
 
-    if RequisiteVerifier::verify(prog.into_bytes(), &config, sbpf_version).is_err() {
+    if RequisiteVerifier::verify(prog.into_bytes(), sbpf_version, &function_registry).is_err() {
         // verify please
         return;
     }

--- a/fuzz/fuzz_targets/smarter_jit_diff.rs
+++ b/fuzz/fuzz_targets/smarter_jit_diff.rs
@@ -32,7 +32,7 @@ fuzz_target!(|data: FuzzData| {
     let config = data.template.into();
     let function_registry = FunctionRegistry::default();
 
-    if RequisiteVerifier::verify(prog.into_bytes(), &config, sbpf_version).is_err() {
+    if RequisiteVerifier::verify(prog.into_bytes(), sbpf_version, &function_registry).is_err() {
         // verify please
         return;
     }

--- a/fuzz/fuzz_targets/smarter_verify.rs
+++ b/fuzz/fuzz_targets/smarter_verify.rs
@@ -5,6 +5,7 @@ use libfuzzer_sys::fuzz_target;
 use semantic_aware::*;
 use solana_sbpf::{
     insn_builder::IntoBytes,
+    program::FunctionRegistry,
     verifier::{RequisiteVerifier, Verifier},
 };
 
@@ -22,10 +23,10 @@ struct FuzzData {
 fuzz_target!(|data: FuzzData| {
     let sbpf_version = data.template.sbpf_version;
     let prog = make_program(&data.prog, sbpf_version);
-    let config = data.template.into();
+    let function_registry = FunctionRegistry::<usize>::default();
 
     #[allow(unused)]
-    let res = RequisiteVerifier::verify(prog.into_bytes(), &config, sbpf_version);
+    let res = RequisiteVerifier::verify(prog.into_bytes(), sbpf_version, &function_registry);
     #[cfg(feature = "only-verified")]
     assert!(res.is_ok(), "Verification failed: {:?}", res.err());
 });

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -415,7 +415,11 @@ impl<C: ContextObject> Executable<C> {
 
     /// Verify the executable
     pub fn verify<V: Verifier>(&self) -> Result<(), EbpfError> {
-        <V as Verifier>::verify(self.get_text_bytes().1, self.get_sbpf_version())?;
+        <V as Verifier>::verify(
+            self.get_text_bytes().1,
+            self.get_sbpf_version(),
+            self.get_loader().get_function_registry(),
+        )?;
         Ok(())
     }
 

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -415,11 +415,7 @@ impl<C: ContextObject> Executable<C> {
 
     /// Verify the executable
     pub fn verify<V: Verifier>(&self) -> Result<(), EbpfError> {
-        <V as Verifier>::verify(
-            self.get_text_bytes().1,
-            self.get_config(),
-            self.get_sbpf_version(),
-        )?;
+        <V as Verifier>::verify(self.get_text_bytes().1, self.get_sbpf_version())?;
         Ok(())
     }
 

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -12,6 +12,7 @@
 
 //! Verifies that the bytecode is valid for the given config.
 
+use crate::program::FunctionRegistry;
 use crate::{ebpf, program::SBPFVersion};
 use thiserror::Error;
 
@@ -87,7 +88,11 @@ pub trait Verifier {
     ///   - Unknown instructions.
     ///   - Bad formed instruction.
     ///   - Unknown eBPF syscall index.
-    fn verify(prog: &[u8], sbpf_version: SBPFVersion) -> Result<(), VerifierError>;
+    fn verify<T>(
+        prog: &[u8],
+        sbpf_version: SBPFVersion,
+        syscall_registry: &FunctionRegistry<T>,
+    ) -> Result<(), VerifierError>;
 }
 
 fn check_prog_len(prog: &[u8]) -> Result<(), VerifierError> {
@@ -218,7 +223,7 @@ pub struct RequisiteVerifier {}
 impl Verifier for RequisiteVerifier {
     /// Check the program against the verifier's rules
     #[rustfmt::skip]
-    fn verify(prog: &[u8], sbpf_version: SBPFVersion) -> Result<(), VerifierError> {
+    fn verify<T>(prog: &[u8], sbpf_version: SBPFVersion, _syscall_registry: &FunctionRegistry<T>) -> Result<(), VerifierError> {
         check_prog_len(prog)?;
 
         let program_range = 0..prog.len() / ebpf::INSN_SIZE;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -12,7 +12,7 @@
 
 //! Verifies that the bytecode is valid for the given config.
 
-use crate::{ebpf, program::SBPFVersion, vm::Config};
+use crate::{ebpf, program::SBPFVersion};
 use thiserror::Error;
 
 /// Error definitions
@@ -87,8 +87,7 @@ pub trait Verifier {
     ///   - Unknown instructions.
     ///   - Bad formed instruction.
     ///   - Unknown eBPF syscall index.
-    fn verify(prog: &[u8], config: &Config, sbpf_version: SBPFVersion)
-        -> Result<(), VerifierError>;
+    fn verify(prog: &[u8], sbpf_version: SBPFVersion) -> Result<(), VerifierError>;
 }
 
 fn check_prog_len(prog: &[u8]) -> Result<(), VerifierError> {
@@ -219,7 +218,7 @@ pub struct RequisiteVerifier {}
 impl Verifier for RequisiteVerifier {
     /// Check the program against the verifier's rules
     #[rustfmt::skip]
-    fn verify(prog: &[u8], _config: &Config, sbpf_version: SBPFVersion) -> Result<(), VerifierError> {
+    fn verify(prog: &[u8], sbpf_version: SBPFVersion) -> Result<(), VerifierError> {
         check_prog_len(prog)?;
 
         let program_range = 0..prog.len() / ebpf::INSN_SIZE;

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -452,15 +452,14 @@ impl Verifier for LocalVerifier {
                     insn_ptr += 1;
                 }
 
-                ebpf::CALL_IMM if insn.src == 0 => {
-                    if syscall_registry.lookup_by_key(insn.imm as u32).is_none() {
-                        return Err(VerifierError::InvalidSyscall(insn.imm as u32));
-                    }
+                ebpf::CALL_IMM
+                    if insn.src == 0
+                        && syscall_registry.lookup_by_key(insn.imm as u32).is_none() =>
+                {
+                    return Err(VerifierError::InvalidSyscall(insn.imm as u32));
                 }
-                ebpf::CALL_IMM if insn.src == 1 => {
-                    if insn.imm == -1 {
-                        return Err(VerifierError::InvalidFunction(insn_ptr));
-                    }
+                ebpf::CALL_IMM if insn.src == 1 && insn.imm == -1 => {
+                    return Err(VerifierError::InvalidFunction(insn_ptr));
                 }
 
                 _ => (),

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -12,8 +12,10 @@
 
 //! Verifies that the bytecode is valid for the given config.
 
-use crate::program::FunctionRegistry;
-use crate::{ebpf, program::SBPFVersion};
+use crate::{
+    ebpf,
+    program::{FunctionRegistry, SBPFVersion},
+};
 use thiserror::Error;
 
 /// Error definitions
@@ -88,7 +90,7 @@ pub trait Verifier {
     ///   - Unknown instructions.
     ///   - Bad formed instruction.
     ///   - Unknown eBPF syscall index.
-    fn verify<T>(
+    fn verify<T: Copy + PartialEq>(
         prog: &[u8],
         sbpf_version: SBPFVersion,
         syscall_registry: &FunctionRegistry<T>,
@@ -419,6 +421,52 @@ impl Verifier for RequisiteVerifier {
         // insn_ptr should now be equal to number of instructions.
         if insn_ptr != prog.len() / ebpf::INSN_SIZE {
             return Err(VerifierError::JumpOutOfCode(insn_ptr, insn_ptr));
+        }
+
+        Ok(())
+    }
+}
+
+/// Verifier to run locally when someone invokes `solana deploy` and the related commands
+#[derive(Debug)]
+pub struct LocalVerifier {}
+
+impl Verifier for LocalVerifier {
+    /// Check if an SBPFv3 program contain any problematic instruction
+    fn verify<T: Copy + PartialEq>(
+        prog: &[u8],
+        sbpf_version: SBPFVersion,
+        syscall_registry: &FunctionRegistry<T>,
+    ) -> Result<(), VerifierError> {
+        if sbpf_version < SBPFVersion::V3 {
+            // Nothing to check
+            return Ok(());
+        }
+
+        let mut insn_ptr: usize = 0;
+        while (insn_ptr + 1) * ebpf::INSN_SIZE <= prog.len() {
+            let insn = ebpf::get_insn(prog, insn_ptr);
+
+            match insn.opc {
+                ebpf::LD_DW_IMM => {
+                    insn_ptr += 1;
+                }
+
+                ebpf::CALL_IMM if insn.src == 0 => {
+                    if syscall_registry.lookup_by_key(insn.imm as u32).is_none() {
+                        return Err(VerifierError::InvalidSyscall(insn.imm as u32));
+                    }
+                }
+                ebpf::CALL_IMM if insn.src == 1 => {
+                    if insn.imm == -1 {
+                        return Err(VerifierError::InvalidFunction(insn_ptr));
+                    }
+                }
+
+                _ => (),
+            }
+
+            insn_ptr += 1;
         }
 
         Ok(())

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -495,19 +495,12 @@ fn exit() {
 
 #[test]
 fn local_verifier_call_negative() {
-    let prog = &[
-        0x07, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // add64 r10, 0
-        0x18, 0x07, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // lddw r7, 0x8000
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // --
-        0x85, 0x10, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, // call -1
-        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
-    ];
-
-    let executable = Executable::<TestContextObject>::from_text_bytes(
-        prog,
+    let executable = assemble::<TestContextObject>(
+        "add64 r10, 0
+        lddw r7, 0x8000
+        call -1
+        exit",
         Arc::new(BuiltinProgram::new_loader(Config::default())),
-        SBPFVersion::V3,
-        FunctionRegistry::default(),
     )
     .unwrap();
 
@@ -517,45 +510,30 @@ fn local_verifier_call_negative() {
 
 #[test]
 fn local_verifier_invalid_syscall() {
-    let prog = &[
-        0x07, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // add64 r10, 0
-        0x18, 0x07, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // lddw r7, 0x8000
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // --
-        0x85, 0x00, 0x00, 0x00, 0x93, 0xd1, 0x1b, 0x00, // call 0x1bd193
-        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
-    ];
-
-    let executable = Executable::<TestContextObject>::from_text_bytes(
-        prog,
+    let executable = assemble::<TestContextObject>(
+        "add64 r10, 0
+        lddw r7, 0x8000
+        syscall 0x1bd193
+        exit",
         Arc::new(BuiltinProgram::new_loader(Config::default())),
-        SBPFVersion::V3,
-        FunctionRegistry::default(),
     )
     .unwrap();
 
     let result = executable.verify::<LocalVerifier>();
-    std::println!("result: {:?}", result);
     assert_error!(result, "VerifierError(InvalidSyscall(1823123))");
 }
 
 #[test]
 fn local_verifier_valid_program() {
-    let prog = &[
-        0x07, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // add64 r10, 0
-        0x18, 0x07, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // lddw r7, 0x8000
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // --
-        0x85, 0x00, 0x00, 0x00, 0xfe, 0xc3, 0xf5, 0x6b, // call 0x1bd193
-        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
-    ];
-
     let mut loader = BuiltinProgram::new_loader(Config::default());
     SyscallU64::register(&mut loader, "log").unwrap();
 
-    let executable = Executable::<TestContextObject>::from_text_bytes(
-        prog,
+    let executable = assemble::<TestContextObject>(
+        "add64 r10, 0
+        lddw r7, 0x8000
+        syscall 0x6bf5c3fe
+        exit",
         Arc::new(loader),
-        SBPFVersion::V3,
-        FunctionRegistry::default(),
     )
     .unwrap();
 

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -45,22 +45,14 @@ pub enum VerifierTestError {
 
 struct TautologyVerifier {}
 impl Verifier for TautologyVerifier {
-    fn verify(
-        _prog: &[u8],
-        _config: &Config,
-        _sbpf_version: SBPFVersion,
-    ) -> std::result::Result<(), VerifierError> {
+    fn verify(_prog: &[u8], _sbpf_version: SBPFVersion) -> std::result::Result<(), VerifierError> {
         Ok(())
     }
 }
 
 struct ContradictionVerifier {}
 impl Verifier for ContradictionVerifier {
-    fn verify(
-        _prog: &[u8],
-        _config: &Config,
-        _sbpf_version: SBPFVersion,
-    ) -> std::result::Result<(), VerifierError> {
+    fn verify(_prog: &[u8], _sbpf_version: SBPFVersion) -> std::result::Result<(), VerifierError> {
         Err(VerifierError::NoProgram)
     }
 }

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -29,10 +29,11 @@ use solana_sbpf::{
     ebpf,
     elf::Executable,
     program::{BuiltinFunctionDefinition, BuiltinProgram, FunctionRegistry, SBPFVersion},
-    verifier::{RequisiteVerifier, Verifier, VerifierError},
+    verifier::{LocalVerifier, RequisiteVerifier, Verifier, VerifierError},
     vm::Config,
 };
 use std::sync::Arc;
+use test_utils::syscalls::SyscallU64;
 use test_utils::{assert_error, create_vm, syscalls, TestContextObject};
 use thiserror::Error;
 
@@ -489,5 +490,75 @@ fn exit() {
     )
     .unwrap();
     let result = executable.verify::<RequisiteVerifier>();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn local_verifier_call_negative() {
+    let prog = &[
+        0x07, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // add64 r10, 0
+        0x18, 0x07, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // lddw r7, 0x8000
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // --
+        0x85, 0x10, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, // call -1
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+
+    let executable = Executable::<TestContextObject>::from_text_bytes(
+        prog,
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
+        SBPFVersion::V3,
+        FunctionRegistry::default(),
+    )
+    .unwrap();
+
+    let result = executable.verify::<LocalVerifier>();
+    assert_error!(result, "VerifierError(InvalidFunction(3))");
+}
+
+#[test]
+fn local_verifier_invalid_syscall() {
+    let prog = &[
+        0x07, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // add64 r10, 0
+        0x18, 0x07, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // lddw r7, 0x8000
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // --
+        0x85, 0x00, 0x00, 0x00, 0x93, 0xd1, 0x1b, 0x00, // call 0x1bd193
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+
+    let executable = Executable::<TestContextObject>::from_text_bytes(
+        prog,
+        Arc::new(BuiltinProgram::new_loader(Config::default())),
+        SBPFVersion::V3,
+        FunctionRegistry::default(),
+    )
+    .unwrap();
+
+    let result = executable.verify::<LocalVerifier>();
+    std::println!("result: {:?}", result);
+    assert_error!(result, "VerifierError(InvalidSyscall(1823123))");
+}
+
+#[test]
+fn local_verifier_valid_program() {
+    let prog = &[
+        0x07, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // add64 r10, 0
+        0x18, 0x07, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, // lddw r7, 0x8000
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // --
+        0x85, 0x00, 0x00, 0x00, 0xfe, 0xc3, 0xf5, 0x6b, // call 0x1bd193
+        0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // exit
+    ];
+
+    let mut loader = BuiltinProgram::new_loader(Config::default());
+    SyscallU64::register(&mut loader, "log").unwrap();
+
+    let executable = Executable::<TestContextObject>::from_text_bytes(
+        prog,
+        Arc::new(loader),
+        SBPFVersion::V3,
+        FunctionRegistry::default(),
+    )
+    .unwrap();
+
+    let result = executable.verify::<LocalVerifier>();
     assert!(result.is_ok());
 }

--- a/tests/verifier.rs
+++ b/tests/verifier.rs
@@ -45,14 +45,22 @@ pub enum VerifierTestError {
 
 struct TautologyVerifier {}
 impl Verifier for TautologyVerifier {
-    fn verify(_prog: &[u8], _sbpf_version: SBPFVersion) -> std::result::Result<(), VerifierError> {
+    fn verify<T>(
+        _prog: &[u8],
+        _sbpf_version: SBPFVersion,
+        _syscall_registry: &FunctionRegistry<T>,
+    ) -> std::result::Result<(), VerifierError> {
         Ok(())
     }
 }
 
 struct ContradictionVerifier {}
 impl Verifier for ContradictionVerifier {
-    fn verify(_prog: &[u8], _sbpf_version: SBPFVersion) -> std::result::Result<(), VerifierError> {
+    fn verify<T>(
+        _prog: &[u8],
+        _sbpf_version: SBPFVersion,
+        _syscall_registry: &FunctionRegistry<T>,
+    ) -> std::result::Result<(), VerifierError> {
         Err(VerifierError::NoProgram)
     }
 }


### PR DESCRIPTION
**Problem**

The verifier on chain and on the CLI does not check for invalid syscalls and invalid call instructions in SBPFv3. Paying to deploy a program to only later (when executing) discover it is unusable is a bad developer experience.

**Solution**

Create another implementation for the `Verifier` trait so that we can customize a verifier for the Solana CLI. Specifically, we want it to run on `solana deploy` and `solana write-buffer` commands.